### PR TITLE
33 auto build dev images

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -1,0 +1,22 @@
+name: Push new dev images
+on:
+  pull_request:
+    branches: [ "main" ]
+    types:
+     - closed
+
+jobs:
+  build:
+    # Build only merged PRs
+    if: (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and Push
+        run: |
+          make multiarch_push_development --file docker/django/Makefile  -e VERSION=$(git rev-parse --short HEAD)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ default_language_version:
   python: "python3.11"
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
      - id: check-added-large-files
      - id: check-ast
@@ -23,13 +23,13 @@ repos:
        args: [--markdown-linebreak-ext=md]
 
   - repo: https://github.com/ikamensh/flynt/
-    rev: '0.76'
+    rev: '0.77'
     hooks:
      - id: flynt
        args: [--line-length=79, --transform-concats]
 
   - repo: https://github.com/psf/black
-    rev: 22.10.0
+    rev: 23.1.0
     hooks:
      - id: black
 

--- a/bc/channel/management/commands/post.py
+++ b/bc/channel/management/commands/post.py
@@ -51,7 +51,6 @@ class Command(BaseCommand):
                 raise ValueError(f"No channel {channel_id}")
 
             if channel.service == Channel.MASTODON:
-
                 self.stdout.write(
                     self.style.SUCCESS(f"Let's toot from {channel.account}!")
                 )

--- a/bc/subscription/api_views.py
+++ b/bc/subscription/api_views.py
@@ -44,7 +44,6 @@ def handle_cl_webhook(request: Request) -> Response:
     results = data["results"]
 
     for result in results:
-
         # TODO: Store docket entry in DB
 
         # Handle any documents attached

--- a/docker/django/Makefile
+++ b/docker/django/Makefile
@@ -26,3 +26,38 @@ development:
 
 image:
 	docker build --target web-prod -t $(REPO):$(DOCKER_TAG_PROD) -t $(REPO):$(WEB_PROD) --file docker/django/Dockerfile .
+
+push: image
+	$(info Checking if valid architecture)
+	@if [ $(UNAME) = "x86_64" ]; then \
+	    echo "Architecture is OK. Pushing.";\
+	    docker push $(REPO):$(DOCKER_TAG_PROD);\
+	else \
+		echo "Only x86_64 machines can push single-architecture builds. If you want to \
+push a build, try 'make multiarch_push', which builds for both arm64 and amd64. This \
+protects against arm64 builds being accidentally deployed to the server (which uses x86_64).";\
+	fi
+
+multiarch_image:
+	export DOCKER_CLI_EXPERIMENTAL=enabled
+	docker buildx rm
+	docker buildx create --use --name flp-builder
+	docker buildx build --platform linux/amd64,linux/arm64 -t $(REPO):$(WEB_PROD) -t $(REPO):$(DOCKER_TAG_PROD) --file docker/django/Dockerfile .
+
+multiarch_push:
+	docker buildx build --push --platform linux/amd64,linux/arm64 -t $(REPO):$(WEB_PROD) -t $(REPO):$(DOCKER_TAG_PROD) --file docker/django/Dockerfile .
+
+x86_push:
+	export DOCKER_CLI_EXPERIMENTAL=enabled
+	docker buildx rm
+	docker buildx create --use --name flp-builder
+	docker buildx build --push --platform linux/amd64 -t $(REPO):$(WEB_PROD) -t $(REPO):$(DOCKER_TAG_PROD) --file docker/django/Dockerfile .
+
+multiarch_push_development:
+	export DOCKER_CLI_EXPERIMENTAL=enabled
+	# Fix for #2116 as per https://github.com/docker/buildx/issues/495#issuecomment-761562905
+	docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+	docker buildx create --name flp-builder --driver docker-container --use
+	# Wait for the builder to boot
+	docker buildx inspect --bootstrap
+	docker buildx build --target web-dev --push --platform linux/amd64,linux/arm64 -t $(REPO):$(WEB_DEV) --build-arg BUILD_ENV=dev --file docker/django/Dockerfile .

--- a/docker/django/README.md
+++ b/docker/django/README.md
@@ -1,0 +1,52 @@
+# Before you build and push
+
+1. Remember to log into docker with `docker login` command
+
+1. Figure out if you need to make a multi-architecture image or just an `amd64` image.
+
+    - Run `uname -m` to figure out if you have an `arm64` or `x86_64` architecture.
+
+    - If you're on an `x86_64` machine, just make a single-architecture build. Skip to the next section.
+
+    - If you're on an `arm_64` machine, you have three options:
+
+      1. Build a single-architecture `arm64` build for your own local development
+      2. Build a single-architecture `x86_64` build that you can push to docker hub (it won't work for you locally, of course)
+      3. Build a multi-architecture `arm64`/`x86_64` build for both local development and to push to docker hub. These take longest to build, but can serve both purposes.
+
+1. Multi-architecture and `x86_64` images can be pushed to docker hub. `arm64` images cause a lot of trouble if they are deployed to the server and thus should only be pushed without the `latest` tag.
+
+
+# Build can be done with:
+
+Change to the root directory and run one of:
+
+    # Make a single-architecture build in the same architecture as your
+    # computer (great for normal dev)
+    make image --file docker/django/Makefile -e VERSION=$(git rev-parse --short HEAD)
+
+    # Make a multi-architecture build
+    make multiarch_image --file docker/django/Makefile -e VERSION=$(git rev-parse --short HEAD)
+
+    # Make an x86_64 build from an arm64 computer
+    make x86_image --file docker/django/Makefile -e VERSION=$(git rev-parse --short HEAD)
+
+# Push new image with:
+
+Change into the root directory, and then run one of:
+
+    # Push a single-architecture x86 build from an x86 machine
+    make push --file docker/django/Makefile -e VERSION=$(git rev-parse --short HEAD)
+
+    # Push a multi-architecture build
+    make multiarch_push --file docker/django/Makefile -e VERSION=$(git rev-parse --short HEAD)
+
+    # Push an x86_64 build from an arm64 computer
+    make x86_push --file docker/django/Makefile -e VERSION=$(git rev-parse --short HEAD)
+
+Each of the above will build the image if it's not already built.
+
+
+# In Practice
+
+1. Docker images are usually made by our continuous deployment pipeline.


### PR DESCRIPTION
This fixes #33 by:

 - Adding a few more features to the make file (all copied from CL)
 - Adding a readme
 - Adding a CI to auto-build and push images to docker (copied from CL)

This should make our lives easier, since it'll mean there are always multi-architecture images ready in docker.

I also pushed our first prod images so they'd be available to k8s: https://hub.docker.com/repository/docker/freelawproject/bigcases2/tags