### PR TITLE
fix(docker compose): Change the POSTGRES_DB variable

### DIFF
--- a/docker/bigcasesbot/docker-compose.yml
+++ b/docker/bigcasesbot/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     environment:
       POSTGRES_USER: "postgres"
       POSTGRES_PASSWORD: "postgres"
-      POSTGRES_DB: "bigcases2"
+      POSTGRES_DB: "bots"
     networks:
       - bc2_net_overlay
 


### PR DESCRIPTION
This PR changes the value of the POSTGRES_DB environment variable to define the name for the default database that is created when the Postgres service is started.

I noticed that after merging https://github.com/freelawproject/bigcases2/pull/50 the django app was failing to start and then I realized the default name of the DB changed.

I think this PR will make developers' life easier.  