### PR TITLE
fix(subscription): Add return value to the has_permission method.

### DIFF
--- a/bc/subscription/api_permissions.py
+++ b/bc/subscription/api_permissions.py
@@ -10,7 +10,7 @@ class AllowListPermission(permissions.BasePermission):
     """
 
     def has_permission(self, request, view):
-        viewer_address = request.META["HTTP_CLOUDFRONT_VIEWER_ADDRESS"]
+        viewer_address = request.META.get("HTTP_CLOUDFRONT_VIEWER_ADDRESS")
         ip_addr = (
             strip_port_to_make_ip_key(viewer_address)
             or request.META["REMOTE_ADDR"]
@@ -20,3 +20,4 @@ class AllowListPermission(permissions.BasePermission):
             return True
         if ip_addr not in settings.COURTLISTENER_ALLOW_IPS:
             raise exceptions.PermissionDenied("Ip not allowed")
+        return True


### PR DESCRIPTION
This PR fixes the endpoint that handles the CL webhooks.

After reviewing the webhook logs, I realize the class that checks the IP address of incoming requests is returning a falsy value when the request is coming from one of the trusted IP and that's the reason the API is throwing error 403 with a message saying that **the Authentication credentials were not provided**.