### PR TITLE
fix(subscriptions):  Allow numberless entries and add minute template

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,4 +40,4 @@ jobs:
           echo "$GITHUB_WORKSPACE/.venv/bin" >> $GITHUB_PATH
 
       - name: Run tests
-        run: python -m unittest discover -s bc -p 'test_*.py'
+        run: python -m unittest discover -s bc -p 'test*.py'

--- a/bc/core/tests.py
+++ b/bc/core/tests.py
@@ -1,4 +1,4 @@
-from django.test import TestCase
+from unittest import TestCase
 
 from bc.core.utils.messages import MastodonTemplate
 

--- a/bc/core/tests.py
+++ b/bc/core/tests.py
@@ -1,0 +1,100 @@
+from django.test import TestCase
+
+from bc.core.utils.messages import MastodonTemplate
+
+
+class MastodonTemplateTest(TestCase):
+    def test_count_fixed_characters(self):
+        template_with_breaks = (
+            "New filing in {docket}\n"
+            "Doc #{doc_num}: {description}\n\n"
+            "PDF: {pdf_link}\n"
+            "Docket: {docket_link}"
+        )
+        tests = (
+            # Simple case
+            {"length": 15, "template": "No placerholder"},
+            # Include placeholders
+            {"length": 0, "template": "{test}"},
+            {"length": 0, "template": "{test}{test_2}{test_3}"},
+            {"length": 1, "template": "{test} {test_2}"},
+            # Include placeholders + text
+            {"length": 17, "template": "One placerholder {test}"},
+            {"length": 19, "template": "Two placerholders {test}:{test}"},
+            {"length": 38, "template": template_with_breaks},
+        )
+
+        for test in tests:
+            test_class = MastodonTemplate(
+                link_placeholders=[], str_template=test["template"]
+            )
+            result = test_class.count_fixed_characters()
+            self.assertEqual(
+                result,
+                test["length"],
+                msg=("Failed with dict: %s.\n" "%s is longer than %s")
+                % (test, result, test["length"]),
+            )
+
+    def test_compute_length_of_template_with_links(self):
+        tests = (
+            # Simple case
+            {"length": 8, "template": "No links", "links": []},
+            # Include links
+            {"length": 23, "template": "{link_1}", "links": ["link_1"]},
+            {
+                "length": 9 + 23,
+                "template": "One link {link_1}",
+                "links": ["link_1"],
+            },
+            {
+                "length": 11 + 23 * 2,
+                "template": "Two links {link_1}:{link_2}",
+                "links": ["link_1", "link_2"],
+            },
+            {
+                "length": 23 * 3,
+                "template": "{link_1}{link_2}{link_3}",
+                "links": ["link_1", "link_2", "link_3"],
+            },
+            # Include links and placeholder
+            {
+                "length": 18 + 23,
+                "template": "link+placeholder {title}:{description}{link}",
+                "links": ["link"],
+            },
+        )
+
+        for test in tests:
+            test_class = MastodonTemplate(
+                link_placeholders=test["links"], str_template=test["template"]
+            )
+            result = len(test_class)
+            self.assertEqual(
+                result,
+                test["length"],
+                msg=("Failed with dict: %s.\n" "%s is longer than %s")
+                % (test, result, test["length"]),
+            )
+
+    def test_truncate_descriptions(self):
+        template = MastodonTemplate(
+            link_placeholders=["link"], str_template="{title}:{description}"
+        )
+
+        tests = (
+            # Simple case
+            {"title": "short title", "description": "short description"},
+            {"title": "short title", "description": 50 * "short"},
+            {"title": "short title", "description": 90 * "short"},
+            {"title": "short title", "description": 101 * "short"},
+            {"title": "short title", "description": 200 * "short"},
+        )
+        for test in tests:
+            result = template.format(**test)
+            self.assertTrue(
+                len(result) <= template.max_characters,
+                msg="Failed with dict: %s.\n"
+                "%s is longer than %s"
+                % (test, result, template.max_characters),
+            )

--- a/bc/core/utils/messages.py
+++ b/bc/core/utils/messages.py
@@ -27,7 +27,7 @@ class MastodonTemplate:
     def count_fixed_characters(self):
         """Returns the number of fixed characters
 
-        this method removes all the placerholders of the template
+        this method removes all the placerholders in the str_template
         using a dictionary that returns a blank string for each key
         and then computes the len of the new string.
         """

--- a/bc/core/utils/messages.py
+++ b/bc/core/utils/messages.py
@@ -52,3 +52,10 @@ Doc #{doc_num}: {description}
 PDF: {pdf_link}
 Docket: {docket_link}""",
 )
+
+
+MINUTE_TEMPLATE = MastodonTemplate(
+    character_count=22,
+    link_placeholders=[],
+    str_template="""New minute entry in {docket}: {description}""",
+)

--- a/bc/subscription/api_views.py
+++ b/bc/subscription/api_views.py
@@ -45,11 +45,12 @@ def handle_cl_webhook(request: Request) -> Response:
     for result in sorted_results:
         cl_docket_id = result["docket"]
         long_description = result["description"]
+        document_number = result.get("entry_number")
         for doc in result["recap_documents"]:
             filing = FilingWebhookEvent.objects.create(
                 docket_id=cl_docket_id,
                 pacer_doc_id=doc["pacer_doc_id"],
-                document_number=doc["document_number"],
+                document_number=document_number,
                 attachment_number=doc.get("attachment_number"),
                 short_description=doc["description"],
                 long_description=long_description,

--- a/bc/subscription/tasks.py
+++ b/bc/subscription/tasks.py
@@ -3,7 +3,7 @@ from django.db import transaction
 from bc.channel.models import Post
 from bc.channel.selectors import get_mastodon_channel
 from bc.channel.utils.masto import post_status as mastodon_post
-from bc.core.utils.messages import POST_TEMPLATE
+from bc.core.utils.messages import MINUTE_TEMPLATE, POST_TEMPLATE
 
 from .models import FilingWebhookEvent, Subscription
 
@@ -35,7 +35,13 @@ def process_filing_webhook_event(fwe_pk) -> FilingWebhookEvent:
     filing_webhook_event.subscription = subscription
     filing_webhook_event.save()
 
-    message = POST_TEMPLATE.format(
+    template = (
+        POST_TEMPLATE
+        if filing_webhook_event.document_number
+        else MINUTE_TEMPLATE
+    )
+
+    message = template.format(
         docket=subscription.docket_name,
         description=filing_webhook_event.description,
         doc_num=filing_webhook_event.document_number,


### PR DESCRIPTION
This PR adds support to allow numberless entries and adds a new template to create posts in Mastodon using the Webhook events. This PR fixes https://github.com/freelawproject/bigcases2/issues/79.