### PR TITLE
feat(core): Add docket link in the template for minute entries

### DIFF
--- a/bc/core/utils/messages.py
+++ b/bc/core/utils/messages.py
@@ -87,6 +87,8 @@ Docket: {docket_link}""",
 
 
 MINUTE_TEMPLATE = MastodonTemplate(
-    link_placeholders=[],
-    str_template="""New minute entry in {docket}: {description}""",
+    link_placeholders=["docket_link"],
+    str_template="""New minute entry in {docket}: {description}
+
+Docket: {docket_link}""",
 )


### PR DESCRIPTION
This PR adds the docket link to the `MINUTE_TEMPLATE`.