### PR TITLE
Change max characters for Mastodon statuses

### DIFF
--- a/bc/core/utils/messages.py
+++ b/bc/core/utils/messages.py
@@ -28,7 +28,7 @@ class AlwaysBlankValueDict(dict):
 class MastodonTemplate:
     str_template: str
     link_placeholders: list[str]
-    max_characters: int = 500
+    max_characters: int = 400
 
     def __len__(self):
         """Returns the length of the template without the placeholders
@@ -76,7 +76,9 @@ class MastodonTemplate:
                 docket = kwargs.get("docket")
                 image = TextImage(f"Case: {docket}", kwargs["description"])
                 kwargs["description"] = trunc(
-                    kwargs["description"], available_space, "…full entry below 👇"
+                    kwargs["description"],
+                    available_space,
+                    "…full entry below 👇",
                 )
 
         return self.str_template.format(**kwargs), image

--- a/bc/core/utils/messages.py
+++ b/bc/core/utils/messages.py
@@ -76,7 +76,7 @@ class MastodonTemplate:
                 docket = kwargs.get("docket")
                 image = TextImage(f"Case: {docket}", kwargs["description"])
                 kwargs["description"] = trunc(
-                    kwargs["description"], available_space, "…👇"
+                    kwargs["description"], available_space, "…full entry below 👇"
                 )
 
         return self.str_template.format(**kwargs), image


### PR DESCRIPTION
This PR updates the `max_character` attribute of the `MastodonTemplate` class (posts will use fewer characters from long descriptions) and changes the string that will be appended to the end of the truncated descriptions.