### PR TITLE
Make too-long posts shorter

### DIFF
--- a/bc/core/utils/messages.py
+++ b/bc/core/utils/messages.py
@@ -28,7 +28,7 @@ class AlwaysBlankValueDict(dict):
 class MastodonTemplate:
     str_template: str
     link_placeholders: list[str]
-    max_characters: int = 400
+    max_characters: int = 300
 
     def __len__(self):
         """Returns the length of the template without the placeholders


### PR DESCRIPTION
This is a second pass at the work in https://github.com/freelawproject/bigcases2/pull/94. 

Looking at this post: https://law.builders/@bigcases/109938980184504362

I think it should be shorter before going to the "See more" so this does that. I think if we're going to provide a picture, then we shouldn't provide so much text.