### PR TITLE
feat(core): Update DO_NOT_POST regex expression

### DIFF
--- a/bc/core/utils/messages.py
+++ b/bc/core/utils/messages.py
@@ -11,7 +11,8 @@ DO_NOT_POST = re.compile(
     notice\sof\sappearance|         #notice of appearance
     certificate\sof\sdisclosure|    #certificate of disclosure
     corporate\sdisclosure|          #corporate disclosure
-    add\sand\sterminate\sattorneys  #add and terminate attorneys
+    add\sand\sterminate\sattorneys| #add and terminate attorneys
+    none                            #entries with bad data
     )""",
     re.VERBOSE | re.IGNORECASE,
 )


### PR DESCRIPTION
This PR fixes https://github.com/freelawproject/bigcases2/issues/92 by adding "None" to the `DO_NOT_POST` regex expression, so the bot won't create posts with bad data.