### PR TITLE
fix(web): Tweak homepage accessibility

### DIFF
--- a/bc/assets/templates/includes/footer.html
+++ b/bc/assets/templates/includes/footer.html
@@ -4,7 +4,7 @@
     <div class="max-w-7xl mx-auto px-4 sm:px-6 md:px-10">
         <section id="footer"class="grid grid-cols-1 sm:grid-cols-3 md:grid-cols-4 gap-8 md:gap-10 lg:gap-12 w-full py-8 justify-start">
           <div class="w-full hidden md:block row-span-1">
-            <img src="{% static "svg/icon.svg" %}"  layout="responsive" class="rounded-lg border-4 border-gray-700 h-24 lg:h-32 xl:h-36 bg-white"/>
+            <img alt='Yellow robot logo' src="{% static "svg/icon.svg" %}"  layout="responsive" class="rounded-lg border-4 border-gray-700 h-24 lg:h-32 xl:h-36 bg-white"/>
           </div>
 
           <div class="w-full">
@@ -75,19 +75,19 @@
                   </div>
                   <!-- Social media icons were downloaded from www.svgrepo.com -->
                   <a rel="me" href="https://law.builders/@flp" class="rounded-full bg-gray-500 p-3">
-                    <img src="{% static "svg/mastodon.svg" %}" alt="mastodon" class="h-5 w-5">
+                    <img alt='Mastodon logo' src="{% static "svg/mastodon.svg" %}" alt="mastodon" class="h-5 w-5">
                   </a>
 
                   <a href="https://twitter.com/freelawproject" class="rounded-full bg-gray-500 p-3">
-                    <img src="{% static "svg/twitter.svg" %}" alt="twitter" class="h-5 w-5">
+                    <img alt='Twitter logo' src="{% static "svg/twitter.svg" %}" alt="twitter" class="h-5 w-5">
                   </a>
 
                   <a href="https://free.law/newsletter/" class="rounded-full bg-gray-500 p-3">
-                   <img src="{% static "svg/newspaper.svg" %}" alt="newsletter" class="h-5 w-5">
+                   <img alt='Newspaper icon' src="{% static "svg/newspaper.svg" %}" alt="newsletter" class="h-5 w-5">
                   </a>
 
                   <a href="https://github.com/freelawproject/" class="rounded-full bg-gray-500 p-3">
-                    <img src="{% static "svg/github.svg" %}" alt="github" class="h-5 w-5">
+                    <img alt='Github logo' src="{% static "svg/github.svg" %}" alt="github" class="h-5 w-5">
                   </a>
                 </div>
             </div>

--- a/bc/assets/templates/includes/footer.html
+++ b/bc/assets/templates/includes/footer.html
@@ -61,8 +61,8 @@
 
 <section class="border-t border-gray-300 mt-0 sm:mt-8 md:mt-16">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 md:px-10">
-        <div class="py-12 flex flex-wrap justify-between" id="colophon">
-            <div class="w-full sm:w-3/5 md:w-1/2 lg:w-2/5 text-gray-400 content-center">
+        <div class="py-12 flex flex-wrap justify-between text-gray-500" id="colophon">
+            <div class="w-full sm:w-3/5 md:w-1/2 lg:w-2/5 content-center">
                 <p class="text-sm">
                 © {% now "Y" %} Free Law Project. Content licensed under a Creative Commons
                 BY-ND international 4.0, license, except where indicated.
@@ -71,7 +71,7 @@
             <div class="w-full sm:w-2/5 md:w-1/2 ">
                 <div class="flex flex-row justify-center pt-6 sm:pt-0 md:justify-end sm:justify-end gap-1">
                   <div class="hidden md:flex items-center mr-4">
-                    <p class="text-gray-400"> Follow us: </p>
+                    <p> Follow us: </p>
                   </div>
                   <!-- Social media icons were downloaded from www.svgrepo.com -->
                   <a rel="me" href="https://law.builders/@flp" class="rounded-full bg-gray-500 p-3">

--- a/bc/assets/templates/includes/header.html
+++ b/bc/assets/templates/includes/header.html
@@ -4,7 +4,7 @@
     <div class="max-w-7xl mx-auto px-4 sm:px-6 md:px-10">
         <div class="flex w-full justify-between items-center py-6 md:space-x-6 lg:space-x-10">
             <div class="absolute top-6">
-                <img src="{% static "svg/icon.svg" %}"  layout="responsive" class="rounded-lg border-4 border-bcb-black h-20 lg:h-24 bg-white"/>
+                <img alt='Yellow robot with white background logo' src="{% static "svg/icon.svg" %}"  layout="responsive" class="rounded-lg border-4 border-bcb-black h-20 lg:h-24 bg-white"/>
             </div>
 
             <div class="w-full md:hidden flex justify-end mx-auto ">
@@ -21,7 +21,7 @@
                     <div class="hidden w-full md:flex md:justify-center gap-6 lg:gap-10">
                         <button class="text-sm lg:text-base flex items-center font-medium uppercase hover:text-gray-700">
                             big cases
-                            <img src="{% static "svg/caret.svg" %}" alt="caret" class="w-5 h-5">
+                            <img alt='Caret icon' src="{% static "svg/caret.svg" %}" alt="caret" class="w-5 h-5">
                         </button>
                         <button class="text-sm lg:text-base font-medium uppercase hover:text-gray-700">
                             little cases

--- a/bc/assets/templates/includes/under_construction.html
+++ b/bc/assets/templates/includes/under_construction.html
@@ -3,8 +3,8 @@
 <div class="relative bg-yellow-400">
 
         <div class="w-100 py-6 uppercase font-semibold flex justify-center gap-3">
-            <img src="{% static "svg/command-line.svg" %}" alt="command line">
+            <img alt="Command line icon" src="{% static "svg/command-line.svg" %}" alt="command line">
             under construction
-            <img src="{% static "svg/exclamation-triangle.svg" %}" alt="exclamation triangle">
+            <img alt="Warning icon" src="{% static "svg/exclamation-triangle.svg" %}" alt="exclamation triangle">
         </div>
 </div>

--- a/bc/web/static_src/src/styles.css
+++ b/bc/web/static_src/src/styles.css
@@ -17,6 +17,7 @@
 }
 
 @font-face {
+    font-display: swap;
     font-family: 'CooperHewitt';
     src: url(/static/fonts/CooperHewitt-Light.woff) format('woff'),
          url(/static/fonts/CooperHewitt-Light.eot) format('embedded-opentype'),
@@ -25,6 +26,7 @@
 }
 
 @font-face {
+    font-display: swap;
     font-family: 'CooperHewitt';
     src: url(/static/fonts/CooperHewitt-Book.woff) format('woff'),
          url(/static/fonts/CooperHewitt-Book.eot) format('embedded-opentype'),
@@ -33,6 +35,7 @@
 }
 
 @font-face {
+    font-display: swap;
     font-family: "CooperHewitt";
     src: url(/static/fonts/CooperHewitt-Bold.woff) format('woff'),
          url(/static/fonts/CooperHewitt-Bold.eot) format('embedded-opentype'),

--- a/bc/web/templates/homepage.html
+++ b/bc/web/templates/homepage.html
@@ -9,7 +9,7 @@
             <h1 class="md:max-w-md xl:max-w-xl font-[800] text-5xl md:text-6xl lg:text-6xl xl:text-7xl text-left">
                 Hi! I’m the bot that keeps you updated about court cases!
             </h1>
-            <img src="{% static "svg/full-body-left-hand.svg" %}" class="hidden sm:block w-32 sm:w-56 md:w-80 lg:w-96 xl:w-[500px]">
+            <img alt='Full body robot holding a gravel' src="{% static "svg/full-body-left-hand.svg" %}" class="hidden sm:block w-32 sm:w-56 md:w-80 lg:w-96 xl:w-[500px]">
         </div>
 
     </div>
@@ -20,7 +20,7 @@
         <div class="py-8 md:py-16 text-white">
             <div class="grid grid-cols-2 flex flex-col justify-center gap-10 pt-6">
                 <div class="flex justify-start self-start">
-                    <img src="{% static "svg/chat-app-logos-combined.svg" %}" class="w-48 object-contain sm:w-64 md:w-72 lg:w-80 xl:w-[490px] xl:h-[440px]">
+                    <img alt='Chat app logos combined' src="{% static "svg/chat-app-logos-combined.svg" %}" class="w-48 object-contain sm:w-64 md:w-72 lg:w-80 xl:w-[490px] xl:h-[440px]">
                 </div>
                 <div class="flex w-full justify-center">
                     <div class="md:max-w-sm lg:max-w-lg flex flex-col">
@@ -30,7 +30,7 @@
                         <p class="pt-5 xl:pt-12 text-md md:text-xl lg:text-2xl xl:text-3xl font-light">
                             Getting updates about cases is important, so I’ll keep you posted on Slack, Discord, MS Teams and more.
                         </p>
-                        <a class="tracking-[.8px] hidden sm:block  text-base bg-saffron-400 hover:bg-saffron-500 text-center whitespace-nowrap border border-transparent mt-8 px-12 py-3 rounded-md md:w-2/3 lg:w-1/2 text-bcb-black">
+                        <a href='#' class="tracking-[.8px] hidden sm:block  text-base bg-saffron-400 hover:bg-saffron-500 text-center whitespace-nowrap border border-transparent mt-8 px-12 py-3 rounded-md md:w-2/3 lg:w-1/2 text-bcb-black">
                             Join the Waitlist
                         </a>
                     </div>
@@ -72,11 +72,11 @@
             </div>
 
             <div class="w-full hidden md:flex mx-auto justify-center items-center">
-                <img src="{% static "svg/free-law-banner.svg" %}"  layout="responsive" class="w-68 object-contain hidden md:block md:w-15"/>
+                <img alt='The FLP logo' src="{% static "svg/free-law-banner.svg" %}"  layout="responsive" class="w-68 object-contain hidden md:block md:w-15"/>
             </div>
 
             <div class="w-full flex justify-center md:hidden row-span-1 align-center items-center">
-                <img src="{% static "svg/free-law-icon.svg" %}"  layout="responsive" class="h-40"/>
+                <img alt='The FLP logo' src="{% static "svg/free-law-icon.svg" %}"  layout="responsive" class="h-40"/>
             </div>
         </section>
         <div class="flex sm:hidden w-full pt-4 flex-col text-md md:text-lg lg:text-2xl font-light">

--- a/bc/web/templates/homepage.html
+++ b/bc/web/templates/homepage.html
@@ -9,7 +9,7 @@
             <h1 class="md:max-w-md xl:max-w-xl font-[800] text-5xl md:text-6xl lg:text-6xl xl:text-7xl text-left">
                 Hi! I’m the bot that keeps you updated about court cases!
             </h1>
-            <img alt='Full body robot holding a gravel' src="{% static "svg/full-body-left-hand.svg" %}" class="hidden sm:block w-32 sm:w-56 md:w-80 lg:w-96 xl:w-[500px]">
+            <img alt='Full body robot holding a gavel' src="{% static "svg/full-body-left-hand.svg" %}" class="hidden sm:block w-32 sm:w-56 md:w-80 lg:w-96 xl:w-[500px]">
         </div>
 
     </div>
@@ -20,7 +20,7 @@
         <div class="py-8 md:py-16 text-white">
             <div class="grid grid-cols-2 flex flex-col justify-center gap-10 pt-6">
                 <div class="flex justify-start self-start">
-                    <img alt='Chat app logos combined' src="{% static "svg/chat-app-logos-combined.svg" %}" class="w-48 object-contain sm:w-64 md:w-72 lg:w-80 xl:w-[490px] xl:h-[440px]">
+                    <img alt='logos for popular chat applications, including Slack, Discord, Microsoft Teams and Google Chat' src="{% static "svg/chat-app-logos-combined.svg" %}" class="w-48 object-contain sm:w-64 md:w-72 lg:w-80 xl:w-[490px] xl:h-[440px]">
                 </div>
                 <div class="flex w-full justify-center">
                     <div class="md:max-w-sm lg:max-w-lg flex flex-col">


### PR DESCRIPTION
This PR fixes accessibility issues from PageSpeed Insights.

This PR introduces the following changes:

- Adds [alt] attributes to the image elements

- Use darker text in the footer

- Use the fallback font to display the text during webfont load