### PR TITLE
feat(masto): Tweak post template

### DIFF
--- a/bc/core/utils/messages.py
+++ b/bc/core/utils/messages.py
@@ -87,7 +87,7 @@ class MastodonTemplate:
 
 POST_TEMPLATE = MastodonTemplate(
     link_placeholders=["pdf_link", "docket_link"],
-    str_template="""New filing in {docket}
+    str_template="""New filing: "{docket}"
 Doc #{doc_num}: {description}
 
 PDF: {pdf_link}


### PR DESCRIPTION
This tweaks the mastodon template a bit to make it a bit clearer. There are a lot of cases that are named "In re...". When we got those, we'd tweet something like, `New filing in In re...`, which is confusing. 

This tweaks it to be `New filing: "In re...."`, which should be better and I think is no longer.