### PR TITLE
fix(web): Update path to the sponsors and about templates

### DIFF
--- a/bc/web/urls.py
+++ b/bc/web/urls.py
@@ -7,12 +7,12 @@ urlpatterns = [
     path("", count_dockets, name="homepage"),
     path(
         "big-cases/about/",
-        TemplateView.as_view(template_name="big_cases/about.html"),
+        TemplateView.as_view(template_name="big-cases/about.html"),
         name="big_cases_about",
     ),
     path(
         "big-cases/sponsors/",
-        TemplateView.as_view(template_name="big_cases/sponsors.html"),
+        TemplateView.as_view(template_name="big-cases/sponsors.html"),
         name="big_cases_sponsors",
     ),
     # Docket pages


### PR DESCRIPTION
This PR fixes the path to the `sponsor.html` and `about.html` files. 

The current implementation of the project is falling to load these pages because is trying to get the templates from a folder called `big_cases` but these files are inside a folder called `big-cases`.