### PR TITLE
feat(subscription): Prompt for case summary in the lookup command

### DIFF
--- a/bc/subscription/management/commands/lookup.py
+++ b/bc/subscription/management/commands/lookup.py
@@ -58,6 +58,13 @@ class Command(BaseCommand):
                 )
             )
 
+        case_summary = input(
+            "\nEnter a summary for this case or press enter to leave it empty:\n\n"
+            "summary: "
+        )
+        if case_summary:
+            result["case_summary"] = case_summary
+
         _, created = create_or_update_subscription_from_docket(result)
         message = "Added!" if created else "Updated!"
         self.stdout.write(self.style.SUCCESS(message))

--- a/bc/subscription/models.py
+++ b/bc/subscription/models.py
@@ -63,6 +63,12 @@ class Subscription(AbstractDateTimeModel):
     )
 
     @property
+    def name_with_summary(self) -> str:
+        if self.case_summary:
+            return f"{self.docket_name} ({self.case_summary})"
+        return self.docket_name
+
+    @property
     def pacer_court_id(self) -> str:
         return map_cl_to_pacer_id(self.cl_court_id)
 

--- a/bc/subscription/services.py
+++ b/bc/subscription/services.py
@@ -11,6 +11,7 @@ def create_or_update_subscription_from_docket(docket):
 
     docket_name = docket["case_name"]
     docket_number = docket["docket_number"]
+    case_summary = docket.get("case_summary", "")
 
     cl_docket_id = docket["id"]
     cl_court_id = docket["court_id"]
@@ -26,6 +27,7 @@ def create_or_update_subscription_from_docket(docket):
             "docket_number": docket_number,
             "cl_court_id": cl_court_id,
             "cl_slug": cl_slug,
+            "case_summary": case_summary,
             "pacer_case_id": pacer_case_id,
             "court_name": court_name,
         },

--- a/bc/subscription/tasks.py
+++ b/bc/subscription/tasks.py
@@ -45,7 +45,7 @@ def process_filing_webhook_event(fwe_pk) -> FilingWebhookEvent:
     )
 
     message, image = template.format(
-        docket=subscription.docket_name,
+        docket=subscription.name_with_summary,
         description=filing_webhook_event.description,
         doc_num=filing_webhook_event.document_number,
         pdf_link=filing_webhook_event.cl_pdf_or_pacer_url,


### PR DESCRIPTION
This PR fixes https://github.com/freelawproject/bigcases2/issues/95

This PR introduces the following changes:

- Prompt for a case summary in the `lookup --add`

- Adds a new property to the `subscription` model that adds the **summary**(when its available) to the **docket name**.

- Use the new property in the mastodon templates.