### PR TITLE
feat(web): Remove Sign In link and set up admin login

### DIFF
--- a/bc/assets/templates/includes/header.html
+++ b/bc/assets/templates/includes/header.html
@@ -91,11 +91,7 @@
                     <a href="https://free.law/donate/" class="text-center whitespace-nowrap border border-transparent rounded-md shadow-sm text-base font-medium text-bcb-black text-sm no-underline bg-saffron-400 hover:bg-saffron-500 inline-flex px-6 py-2 sm:text-md">
                         &nbsp;Donate
                     </a>
-                    <a href='#' class="text-center whitespace-nowrap border border-transparent rounded-md shadow-sm text-base font-medium text-white text-sm no-underline border-gray-700 hover:border-gray-900 bg-neutral-800 hidden sm:inline-flex px-6 py-2 sm:text-md">
-                        Sign In
-                    </a>
                 </div>
-
             </div>
         </div>
     </div>

--- a/bc/assets/templates/includes/submit-button.html
+++ b/bc/assets/templates/includes/submit-button.html
@@ -1,5 +1,5 @@
 <input
     type="submit"
-    value="Submit"
+    value={{value}}
     name="submit"
     class="tracking-[.8px] text-center whitespace-nowrap border border-transparent rounded-md shadow-sm text-base font-medium no-underline px-4 py-2 sm:text-md cursor bg-saffron-400 hover:bg-saffron-500"/>

--- a/bc/channel/admin.py
+++ b/bc/channel/admin.py
@@ -1,0 +1,5 @@
+from django.contrib import admin
+
+from .models import Channel
+
+admin.site.register(Channel)

--- a/bc/core/utils/network.py
+++ b/bc/core/utils/network.py
@@ -1,7 +1,8 @@
-from typing import Optional
+from django.http import HttpRequest
+from django_ratelimit.core import get_header
 
 
-def strip_port_to_make_ip_key(ip_str: str | None) -> str | None:
+def strip_port_to_make_ip_key(group: str, request: HttpRequest) -> str | None:
     """Make a good key to use for caching the request's IP
 
     CloudFront provides a header that returns the user's IP and port,
@@ -18,6 +19,5 @@ def strip_port_to_make_ip_key(ip_str: str | None) -> str | None:
     :param ip_str: the IP address of the viewer and the source port of the request
     :return: A simple key that can be used to throttle the user if needed.
     """
-    if ip_str:
-        return ip_str.split(":")[0]
-    return None
+    header = get_header(request, "CloudFront-Viewer-Address")
+    return header.split(":")[0]

--- a/bc/core/utils/network.py
+++ b/bc/core/utils/network.py
@@ -1,5 +1,6 @@
 from django.http import HttpRequest
 from django_ratelimit.core import get_header
+from django_ratelimit.decorators import ratelimit
 
 
 def strip_port_to_make_ip_key(group: str, request: HttpRequest) -> str | None:
@@ -21,3 +22,11 @@ def strip_port_to_make_ip_key(group: str, request: HttpRequest) -> str | None:
     """
     header = get_header(request, "CloudFront-Viewer-Address")
     return header.split(":")[0]
+
+
+ratelimiter_unsafe_10_per_m = ratelimit(
+    key=strip_port_to_make_ip_key,
+    rate="10/m",
+    method=ratelimit.UNSAFE,
+    block=True,
+)

--- a/bc/core/utils/network.py
+++ b/bc/core/utils/network.py
@@ -3,7 +3,7 @@ from django_ratelimit.core import get_header
 from django_ratelimit.decorators import ratelimit
 
 
-def strip_port_to_make_ip_key(group: str, request: HttpRequest) -> str | None:
+def strip_port_to_make_ip_key(group: str, request: HttpRequest) -> str:
     """Make a good key to use for caching the request's IP
 
     CloudFront provides a header that returns the user's IP and port,
@@ -17,7 +17,8 @@ def strip_port_to_make_ip_key(group: str, request: HttpRequest) -> str | None:
 
         96.23.39.106
 
-    :param ip_str: the IP address of the viewer and the source port of the request
+    :param group: Unused: The group key from the ratelimiter
+    :param request: The HTTP request from the user
     :return: A simple key that can be used to throttle the user if needed.
     """
     header = get_header(request, "CloudFront-Viewer-Address")

--- a/bc/settings/django.py
+++ b/bc/settings/django.py
@@ -135,6 +135,9 @@ if not any([TESTING, DEBUG]):
         "bc.core.utils.storage.SubDirectoryS3ManifestStaticStorage"
     )
 
+LOGIN_URL = "/sign-in/"
+LOGIN_REDIRECT_URL = "/"
+
 # Default primary key field type
 # https://docs.djangoproject.com/en/4.1/ref/settings/#default-auto-field
 

--- a/bc/subscription/api_permissions.py
+++ b/bc/subscription/api_permissions.py
@@ -10,9 +10,8 @@ class AllowListPermission(permissions.BasePermission):
     """
 
     def has_permission(self, request, view):
-        viewer_address = request.META.get("HTTP_CLOUDFRONT_VIEWER_ADDRESS")
         ip_addr = (
-            strip_port_to_make_ip_key(viewer_address)
+            strip_port_to_make_ip_key(group="", request=request)
             or request.META["REMOTE_ADDR"]
         )
 

--- a/bc/subscription/models.py
+++ b/bc/subscription/models.py
@@ -104,7 +104,7 @@ class Subscription(AbstractDateTimeModel):
 
     def __str__(self) -> str:
         if self.docket_name:
-            return f"{self.pk}: {self.docket_name}"
+            return f"{self.pk}: {self.name_with_summary}"
         else:
             return f"{self.pk}"
 

--- a/bc/urls.py
+++ b/bc/urls.py
@@ -2,9 +2,16 @@ from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
 from django.urls import include, path
+from django.views.generic import RedirectView
 
 urlpatterns = [
+    path(
+        # Redirect admin login to our ratelimited version.
+        "admin/login/",
+        RedirectView.as_view(url="/sign-in/", permanent=False),
+    ),
     path("admin/", admin.site.urls),
+    path("", include("bc.users.urls")),
     path("", include("bc.web.urls")),
     path("", include("bc.core.urls")),
     path("", include("bc.channel.urls")),

--- a/bc/users/templates/register/login.html
+++ b/bc/users/templates/register/login.html
@@ -1,0 +1,33 @@
+{% extends "base.html" %}
+
+{% block title %}Sign In{% endblock %}
+
+{% block content %}
+<div class="max-w-xl mx-auto px-4 sm:px-6 md:px-10">
+  <div class="py-12 prose">
+    <h1 class="font-display font-light tracking-wide">Sign In</h2>
+    {% if form.errors %}
+        {%  for error in form.non_field_errors %}
+        <p class="alert alert-danger">{{ error|safe }}</p>
+        {% endfor %}
+    {% endif %}
+
+    <form action="{% url "sign-in" %}" method="post">
+        {% csrf_token %}
+    <div class="grid grid-cols-1 gap-4">
+        {% for field in form %}
+            <div class="flex flex-col">
+                <div>
+                    {{ field.label_tag }}
+                </div>
+                {{ field }}
+            </div>
+        {% endfor %}
+        <input type="hidden" name="next" value="{{ next }}">
+
+        {% include 'includes/submit-button.html' with value='Sign In' %}
+        </div>
+    </form>
+  </div>
+</div>
+{% endblock %}

--- a/bc/users/templates/register/login.html
+++ b/bc/users/templates/register/login.html
@@ -6,28 +6,28 @@
 <div class="max-w-xl mx-auto px-4 sm:px-6 md:px-10">
   <div class="py-12 prose">
     <h1 class="font-display font-light tracking-wide">Sign In</h2>
-    {% if form.errors %}
-        {%  for error in form.non_field_errors %}
-        <p class="alert alert-danger">{{ error|safe }}</p>
+      {% if form.errors %}
+        {% for error in form.non_field_errors %}
+          <p class="alert alert-danger">{{ error|safe }}</p>
         {% endfor %}
-    {% endif %}
+      {% endif %}
 
-    <form action="{% url "sign-in" %}" method="post">
+      <form action="{% url "sign-in" %}" method="post">
         {% csrf_token %}
-    <div class="grid grid-cols-1 gap-4">
-        {% for field in form %}
+        <div class="grid grid-cols-1 gap-4">
+          {% for field in form %}
             <div class="flex flex-col">
-                <div>
-                    {{ field.label_tag }}
-                </div>
-                {{ field }}
+              <div>
+                {{ field.label_tag }}
+              </div>
+              {{ field }}
             </div>
-        {% endfor %}
-        <input type="hidden" name="next" value="{{ next }}">
+          {% endfor %}
+          <input type="hidden" name="next" value="{{ next }}">
 
-        {% include 'includes/submit-button.html' with value='Sign In' %}
+          {% include 'includes/submit-button.html' with value='Sign In' %}
         </div>
-    </form>
+      </form>
   </div>
 </div>
 {% endblock %}

--- a/bc/users/urls.py
+++ b/bc/users/urls.py
@@ -8,12 +8,7 @@ urlpatterns = [
     path(
         "sign-in/",
         ratelimiter_unsafe_10_per_m(
-            auth_views.LoginView.as_view(
-                **{
-                    "template_name": "register/login.html",
-                    "extra_context": {"private": False},
-                }
-            )
+            auth_views.LoginView.as_view(template_name="register/login.html")
         ),
         name="sign-in",
     )

--- a/bc/users/urls.py
+++ b/bc/users/urls.py
@@ -1,0 +1,20 @@
+from django.contrib.auth import views as auth_views
+from django.urls import path
+
+from bc.core.utils.network import ratelimiter_unsafe_10_per_m
+
+urlpatterns = [
+    # Sign in page
+    path(
+        "sign-in/",
+        ratelimiter_unsafe_10_per_m(
+            auth_views.LoginView.as_view(
+                **{
+                    "template_name": "register/login.html",
+                    "extra_context": {"private": False},
+                }
+            )
+        ),
+        name="sign-in",
+    )
+]

--- a/bc/web/templates/includes/suggestion-form.html
+++ b/bc/web/templates/includes/suggestion-form.html
@@ -45,7 +45,7 @@
             </div>
 
 
-            {% include './submit-button.html'%}
+            {% include 'includes/submit-button.html' with value='Submit' %}
 
         </div>
     </form>

--- a/bc/web/templates/includes/waitlist-form.html
+++ b/bc/web/templates/includes/waitlist-form.html
@@ -46,7 +46,7 @@
                 </div>
             </div>
 
-            {% include './submit-button.html'%}
+            {% include 'includes/submit-button.html' with value='Submit' %}
         </div>
     </form>
 </div>

--- a/poetry.lock
+++ b/poetry.lock
@@ -623,6 +623,18 @@ docs = ["furo (>=2021.8.17b43,<2021.9.0)", "sphinx (>=3.5.0)", "sphinx-notfound-
 testing = ["coverage[toml] (>=5.0a4)", "pytest (>=4.6.11)"]
 
 [[package]]
+name = "django-ratelimit"
+version = "4.0.0"
+description = "Cache-based rate-limiting for Django."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "django-ratelimit-4.0.0.tar.gz", hash = "sha256:19cba9e8101277f28c7a974c54c997067341ab30175431d3739e8ffb63cdd2b2"},
+    {file = "django_ratelimit-4.0.0-py2.py3-none-any.whl", hash = "sha256:a610b5fd052c843a589084f6934bc6d827ec6242d5965110ebd436ca5a59ef39"},
+]
+
+[[package]]
 name = "django-rq"
 version = "2.7.0"
 description = "An app that provides django integration for RQ (Redis Queue)"
@@ -2110,4 +2122,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "5504203afe367068eace7afe79d95e25d171fc4e1ca4a0fe5286fcab9404072c"
+content-hash = "2422940f1b97d169ecf732b9aa9479449ad709970a24d14b5ab594c6ceaca3a1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ pillow = "^9.4.0"
 django-storages = "^1.13.2"
 boto3 = "^1.26.80"
 django-tailwind = "^3.5.0"
+django-ratelimit = "^4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 black = "^23.1.0"


### PR DESCRIPTION
This PR removes the Sign In link on the header, adds django-ratelimit as a dependency, and redirects the admin login to a custom login page that uses a ratelimiting decorator. 

Here's a screenshot of the login page:

![image](https://user-images.githubusercontent.com/55959657/226033641-dc9cd979-631d-4e00-a4c5-a9ed7ffe37ec.png)
