### PR TITLE
feat(web): Add the mobile menu

### DIFF
--- a/bc/assets/static-global/js/dropdown.js
+++ b/bc/assets/static-global/js/dropdown.js
@@ -3,12 +3,14 @@ var Default = {
 };
 
 var Dropdown =  (function () {
-    function Dropdown(targetElement, triggerElement, options) {
+    function Dropdown(targetElement, triggerElement, closeButton,options) {
         if (targetElement === void 0) { targetElement = null; }
         if (triggerElement === void 0) { triggerElement = null; }
+        if (closeButton === void 0) { closeButton = null; }
         if (options === void 0) { options = Default; }
         this._targetEl = targetElement;
         this._triggerEl = triggerElement;
+        this._closeButton = closeButton;
         this._visible = false;
         this._init();
     }
@@ -31,6 +33,11 @@ var Dropdown =  (function () {
             _this._triggerEl.addEventListener(ev, function () {
                 _this.toggle();
             });
+            if (_this._closeButton){
+              _this._closeButton.addEventListener(ev, function () {
+                _this.toggle();
+            });
+            }
         });
 
     };
@@ -90,9 +97,11 @@ function initDropdowns() {
         .querySelectorAll('[data-dropdown-toggle]')
         .forEach(function ($triggerEl) {
         var dropdownId = $triggerEl.getAttribute('data-dropdown-toggle');
+        var closeButtonId = $triggerEl.getAttribute('data-dropdown-close-button');
         var $dropdownEl = document.getElementById(dropdownId);
+        var $closeButton = document.getElementById(closeButtonId)
         if ($dropdownEl) {
-            new Dropdown($dropdownEl, $triggerEl);
+            new Dropdown($dropdownEl, $triggerEl, $closeButton);
         }
         else {
             console.error("The dropdown element with id \"".concat(dropdownId, "\" does not exist. Please check the data-dropdown-toggle attribute."));

--- a/bc/assets/static-global/js/dropdown.js
+++ b/bc/assets/static-global/js/dropdown.js
@@ -88,6 +88,10 @@ var Dropdown =  (function () {
         // Disable the event listeners
         this._visible = false;
         this._removeClickOutsideListener();
+        setTimeout(() => {
+          this._targetEl.classList.remove("block");
+          this._targetEl.classList.add("hidden");
+        }, 200);
     };
     return Dropdown;
 }());

--- a/bc/assets/templates/includes/header.html
+++ b/bc/assets/templates/includes/header.html
@@ -10,12 +10,57 @@
             </div>
 
             <div class="w-full md:hidden flex justify-end mx-auto ">
-
-                <button type="button" class="navbar-burger rounded-md items-center text-amber-400 p-1 hover:text-amber-600 focus:outline-none focus:ring-2 focus:ring-gray-300">
+                <button type="button" data-dropdown-toggle="dropdown-mobile" data-dropdown-close-button="close-dropdown-mobile" class="navbar-burger rounded-md items-center text-amber-400 p-1 hover:text-amber-600 focus:outline-none focus:ring-2 focus:ring-gray-300">
                     <div class="h-6 w-6">
-                        <svg xmlns="http://www.w3.org/2000/svg" class="flex-shrink-0 fill-current" viewBox="0 0 20 20"><path d="M0 3h20v2H0V3zm0 6h20v2H0V9zm0 6h20v2H0v-2z"/></svg>
+                      {% include './inlines/bars.svg' %}
                     </div>
                 </button>
+                <div class="absolute w-full pl-8 sm:pl-12">
+
+                  <div id="dropdown-mobile" class="z-10 bg-white hidden divide-y divide-gray-100 rounded-lg shadow-lg ring-1 ring-black ring-opacity-5 overflow-hidden w-full">
+                    <div class="pt-5 pb-6 px-5">
+                      <div class="flex items-start justify-between">
+                        <img alt='Yellow robot with white background logo' src="{% static "svg/icon.svg" %}"  layout="responsive" class="rounded-lg h-16 w-16 bg-white"/>
+                        <button type="button" id="close-dropdown-mobile" class="navbar-burger rounded-md items-center text-amber-400 p-1 hover:text-amber-600 focus:outline-none focus:ring-2 focus:ring-gray-300">
+                            <div class="h-6 w-6">
+                              {% include './inlines/x-mark.svg' %}
+                            </div>
+                        </button>
+                      </div>
+                    </div>
+                    <div class="py-6 px-5 space-y-6">
+                      <div class="grid grid-cols-2 gap-x-6 sm:gap-x-8">
+                        <div class="grid grid-cols-1 gap-y-4">
+                          <a href="{% url 'big_cases_about' %}" class="text-base font-medium text-gray-900 hover:text-gray-700">About Me</a>
+                          <a href="{% url 'big_cases_sponsors' %}" class="text-base font-medium text-gray-900 hover:text-gray-700">Sponsors Me</a>
+                        </div>
+
+                        <div class="grid grid-cols-1 gap-y-4">
+                          <a href="{% url 'little_cases' %}" class="text-base font-medium text-gray-900 hover:text-gray-700">Little Cases bots</a>
+                          <a href="{% url 'collaboration' %}" class="text-base font-medium text-gray-900 hover:text-gray-700">Chat Apps</a>
+                        </div>
+                      </div>
+                      <div class="grid grid-cols-1 gap-2">
+                        <a href="https://free.law/donate/" class="w-full flex items-center justify-center px-4 py-2 border border-transparent rounded-md shadow-sm font-medium text-sm no-underline text-bcb-black  bg-saffron-400 hover:bg-saffron-500">
+                            &nbsp;Donate
+                        </a>
+                        <a rel="me" href="https://law.builders/@bigcases" class="w-full flex items-center justify-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium border-gray-500">
+                            <div class="h-6 w-6 text-gray-400">
+                                {% include './inlines/mastodon.svg' %}
+                            </div>
+                            Follow on Mastodon
+                        </a>
+                        <a href="https://twitter.com/big_cases" class="w-full flex p-3 items-center justify-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium border-gray-500">
+                            <div class="h-6 w-6 text-gray-400">
+                                {% include './inlines/twitter.svg' %}
+                            </div>
+                            Follow on Twitter
+                        </a>
+                      </div>
+                    </div>
+
+                  </div>
+                </div>
             </div>
 
             <div class="hidden w-full md:flex md:justify-end lg:justify-center">

--- a/bc/assets/templates/includes/inlines/x-mark.svg
+++ b/bc/assets/templates/includes/inlines/x-mark.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="flex-shrink-0 fill-current" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+</svg>

--- a/bc/web/templates/big-cases/about.html
+++ b/bc/web/templates/big-cases/about.html
@@ -53,5 +53,13 @@
     </tbody>
   </table>
 
-
+  <h2>What next?</h2>
+  <div class="grid grid-cols-2 gap-8">
+    <a href="{% url 'big_cases_my_code' %}" class="text-center whitespace-nowrap border rounded-md shadow-sm font-medium text-sm no-underline w-full inline-block border-gray-500 hover:border-gray-900 hover:text-gray-900 bg-white px-4 py-2 sm:text-md">
+      My Technology
+    </a>
+    <a href="{% url 'big_cases_sponsors' %}" class="text-center whitespace-nowrap border rounded-md shadow-sm font-medium  text-sm no-underline w-full inline-block border-gray-500 hover:border-gray-900 hover:text-gray-900 bg-white px-4 py-2 sm:text-md">
+      Sponsors Me
+    </a>
+  </div>
 {% endblock %}


### PR DESCRIPTION
This PR adds the mobile menu to the website and fixes https://github.com/freelawproject/bigcases2/issues/142. 

This PR also adds the "What next?" section to bottom of the about page. 

Here's a gif of the mobile menu: 

![mobile-menu](https://user-images.githubusercontent.com/55959657/227589133-3694aa91-a7b9-4910-ab3b-bb75d538054e.gif)

This is the "What next" section in the about page:

![image](https://user-images.githubusercontent.com/55959657/227589621-fb9b743c-e646-4daa-8ef8-44133ba763ef.png)
