### PR TITLE
feat(subscription): Add a post after subscribing to a new case.

### DIFF
--- a/bc/core/utils/status/templates.py
+++ b/bc/core/utils/status/templates.py
@@ -1,6 +1,6 @@
 import re
 
-from .base import MastodonTemplate, TwitterTemplate
+from .base import BaseTemplate, MastodonTemplate, TwitterTemplate
 
 DO_NOT_POST = re.compile(
     r"""(
@@ -44,4 +44,13 @@ TWITTER_MINUTE_TEMPLATE = TwitterTemplate(
     str_template="""New minute entry in {docket}: {description}
 
 Docket: {docket_link}""",
+)
+
+
+FOLLOW_A_NEW_CASE_TEMPLATE = BaseTemplate(
+    link_placeholders=[],
+    max_characters=280,
+    str_template="""I'm now following {docket}:
+
+{docket_link}""",
 )


### PR DESCRIPTION
This PR tweaks the `lookup` command to create a new status in each enabled channel after subscribing to a new case. This PR fixes https://github.com/freelawproject/bigcases2/issues/112.

Here are screenshots of the posts created after subscribing:

![image](https://user-images.githubusercontent.com/55959657/227951374-af06f6bb-d3a6-4552-b6b1-ae7c259e095b.png)


![image](https://user-images.githubusercontent.com/55959657/227951233-b4408de2-6460-4c2d-abce-b9c1bb9f04da.png)
