### PR TITLE
feat(templates): Add the aria-label attribute to links and buttons

### DIFF
--- a/bc/assets/templates/includes/footer-link.html
+++ b/bc/assets/templates/includes/footer-link.html
@@ -1,3 +1,3 @@
 <p class="pb-2 sm:pb-3 md:pb-4">
-    <a href={{href}} class="text-gray-500 hover:underline">{{text}}</a>
+    <a href={{href}} class="text-gray-500 hover:underline" aria-label="{{text}}">{{text}}</a>
 </p>

--- a/bc/assets/templates/includes/footer.html
+++ b/bc/assets/templates/includes/footer.html
@@ -94,7 +94,7 @@
                     </div>
                   </a>
 
-                  <a href="https://github.com/freelawproject/" class="rounded-full bg-gray-500 p-3">
+                  <a href="https://github.com/freelawproject/" class="rounded-full bg-gray-500 p-3" aria-label="GitHub">
                     <div class="h-5 w-5 text-white">
                       {% include './inlines/github.svg' %}
                     </div>

--- a/bc/assets/templates/includes/header.html
+++ b/bc/assets/templates/includes/header.html
@@ -10,7 +10,7 @@
             </div>
 
             <div class="w-full md:hidden flex justify-end mx-auto ">
-                <button type="button" data-dropdown-toggle="dropdown-mobile" data-dropdown-close-button="close-dropdown-mobile" class="navbar-burger rounded-md items-center text-amber-400 p-1 hover:text-amber-600 focus:outline-none focus:ring-2 focus:ring-gray-300">
+                <button type="button" aria-label="Mobile button" data-dropdown-toggle="dropdown-mobile" data-dropdown-close-button="close-dropdown-mobile" class="navbar-burger rounded-md items-center text-amber-400 p-1 hover:text-amber-600 focus:outline-none focus:ring-2 focus:ring-gray-300">
                     <div class="h-6 w-6">
                       {% include './inlines/bars.svg' %}
                     </div>
@@ -31,26 +31,26 @@
                     <div class="py-6 px-5 space-y-6">
                       <div class="grid grid-cols-2 gap-x-6 sm:gap-x-8">
                         <div class="grid grid-cols-1 gap-y-4">
-                          <a href="{% url 'big_cases_about' %}" class="text-base font-medium text-gray-900 hover:text-gray-700">About Me</a>
-                          <a href="{% url 'big_cases_sponsors' %}" class="text-base font-medium text-gray-900 hover:text-gray-700">Sponsors Me</a>
+                          <a href="{% url 'big_cases_about' %}" class="text-base font-medium text-gray-900 hover:text-gray-700" aria-label="About Me">About Me</a>
+                          <a href="{% url 'big_cases_sponsors' %}" class="text-base font-medium text-gray-900 hover:text-gray-700" aria-label="Sponsors Me">Sponsors Me</a>
                         </div>
 
                         <div class="grid grid-cols-1 gap-y-4">
-                          <a href="{% url 'little_cases' %}" class="text-base font-medium text-gray-900 hover:text-gray-700">Little Cases bots</a>
-                          <a href="{% url 'collaboration' %}" class="text-base font-medium text-gray-900 hover:text-gray-700">Chat Apps</a>
+                          <a href="{% url 'little_cases' %}" class="text-base font-medium text-gray-900 hover:text-gray-700" aria-label="Little Cases bots">Little Cases bots</a>
+                          <a href="{% url 'collaboration' %}" class="text-base font-medium text-gray-900 hover:text-gray-700" aria-label="Chat Apps">Chat Apps</a>
                         </div>
                       </div>
                       <div class="grid grid-cols-1 gap-2">
-                        <a href="https://free.law/donate/" class="w-full flex items-center justify-center px-4 py-2 border border-transparent rounded-md shadow-sm font-medium text-sm no-underline text-bcb-black  bg-saffron-400 hover:bg-saffron-500">
+                        <a href="https://free.law/donate/" aria-label="Donate" class="w-full flex items-center justify-center px-4 py-2 border border-transparent rounded-md shadow-sm font-medium text-sm no-underline text-bcb-black  bg-saffron-400 hover:bg-saffron-500">
                             &nbsp;Donate
                         </a>
-                        <a rel="me" href="https://law.builders/@bigcases" class="w-full flex items-center justify-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium border-gray-500">
+                        <a rel="me" href="https://law.builders/@bigcases" aria-label="Mastodon" class="w-full flex items-center justify-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium border-gray-500">
                             <div class="h-6 w-6 text-gray-400">
                                 {% include './inlines/mastodon.svg' %}
                             </div>
                             Follow on Mastodon
                         </a>
-                        <a href="https://twitter.com/big_cases" class="w-full flex p-3 items-center justify-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium border-gray-500">
+                        <a href="https://twitter.com/big_cases" aria-label="Twitter" class="w-full flex p-3 items-center justify-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium border-gray-500">
                             <div class="h-6 w-6 text-gray-400">
                                 {% include './inlines/twitter.svg' %}
                             </div>
@@ -67,7 +67,7 @@
                 <div class="flex w-10/12 md:gap-2 lg:gap-10 justify-center">
                     <div class="hidden w-full md:flex md:justify-center gap-6 lg:gap-10">
                         <div class="flex flex-col">
-                            <button id="bigCasesButton" data-dropdown-toggle="dropdown" class="text-sm lg:text-base flex items-center font-medium uppercase hover:text-gray-700">
+                            <button id="bigCasesButton" data-dropdown-toggle="dropdown" class="text-sm lg:text-base flex items-center font-medium uppercase hover:text-gray-700" aria-label="Big cases button">
                                 big cases
                                 <div class="w-5 h-5">
                                     {% include './inlines/caret.svg' %}
@@ -76,7 +76,7 @@
                             <div class="absolute top-16 -translate-x-8 xl:-translate-x-32">
                                 <div id="dropdown" class="z-10 bg-white hidden divide-y divide-gray-100 rounded-lg shadow-lg ring-1 ring-black ring-opacity-5 overflow-hidden max-w-xs md:w-screen lg:max-w-md">
                                     <div class="relative grid px-5 py-6 gap-4 text-sm text-gray-700 dark:text-gray-400 md:gap-8 sm:p-8" aria-labelledby="dropdownNavbarButton">
-                                        <a href="{% url 'big_cases_about' %}" class="flex items-start -m-3 p-3 hover:bg-gray-100">
+                                        <a href="{% url 'big_cases_about' %}" class="flex items-start -m-3 p-3 hover:bg-gray-100" aria-label="About Me">
                                             <div class="h-6 w-6 relative flex-shrink-0">
                                                 {% include './inlines/information-circle.svg' %}
                                             </div>
@@ -86,7 +86,7 @@
                                             </div>
                                         </a>
 
-                                        <a href="{% url 'big_cases_sponsors' %}" class="flex items-start -m-3 p-3 hover:bg-gray-100">
+                                        <a href="{% url 'big_cases_sponsors' %}" class="flex items-start -m-3 p-3 hover:bg-gray-100" aria-label="Sponsors Me">
                                             <div class="h-6 w-6 relative flex-shrink-0">
                                                 {% include './inlines/sponsors.svg' %}
                                             </div>
@@ -98,7 +98,7 @@
                                     </div>
                                     <div class="px-5 py-1 bg-gray-50 flex md:py-2 md:px-8">
                                         <div class="w-1/2">
-                                            <a rel="me" href="https://law.builders/@bigcases" class="flex p-3 items-center justify-center rounded-md hover:bg-gray-100">
+                                            <a rel="me" href="https://law.builders/@bigcases" aria-label="Mastodon" class="flex p-3 items-center justify-center rounded-md hover:bg-gray-100">
                                                 <div class="h-6 w-6 text-gray-400">
                                                     {% include './inlines/mastodon.svg' %}
                                                 </div>
@@ -108,7 +108,7 @@
                                             </a>
                                         </div>
                                         <div class="w-1/2">
-                                            <a href="https://twitter.com/big_cases" class="flex p-3 items-center justify-center rounded-md hover:bg-gray-100">
+                                            <a href="https://twitter.com/big_cases" aria-label="Twitter" class="flex p-3 items-center justify-center rounded-md hover:bg-gray-100">
                                                 <div class="h-6 w-6 text-gray-400">
                                                     {% include './inlines/twitter.svg' %}
                                                 </div>
@@ -121,10 +121,10 @@
                                 </div>
                             </div>
                         </div>
-                        <a href="{% url 'little_cases' %}" class="text-sm lg:text-base font-medium uppercase hover:text-gray-700">
+                        <a href="{% url 'little_cases' %}" aria-label="little cases" class="text-sm lg:text-base font-medium uppercase hover:text-gray-700">
                             little cases
                         </a>
-                        <a href="{% url 'collaboration' %}" class="text-sm lg:text-base font-medium uppercase hover:text-gray-700">
+                        <a href="{% url 'collaboration' %}" aria-label="Chat Apps" class="text-sm lg:text-base font-medium uppercase hover:text-gray-700">
                             Chat Apps
                         </a>
                     </div>


### PR DESCRIPTION
This PR adds the `aria-label` attribute to the HTML templates. This attribute fixes the following issues from the [PageSpeed report](https://pagespeed.web.dev/analysis/https-bots-law/34i2g5b1w1?form_factor=mobile):

- Buttons do not have an accessible name
- Links do not have a discernible name