### PR TITLE
feat(subscription): Update the pdf link to add the new parameter

### DIFF
--- a/bc/subscription/models.py
+++ b/bc/subscription/models.py
@@ -207,7 +207,7 @@ class FilingWebhookEvent(AbstractDateTimeModel):
 
     @property
     def cl_pdf_or_pacer_url(self) -> str:
-        return f"{self.cl_document_url}?redirect_to_download=True"
+        return f"{self.cl_document_url}?redirect_or_modal=True"
 
     @property
     def cl_docket_url(self) -> str | None:


### PR DESCRIPTION
This PR removes the parameter `redirect_to_download` from the PDF link and uses the new parameter called `redirect_or_modal` instead.

Here's one tweet that uses the new link:

https://twitter.com/flp_tests/status/1641238923274797058