### PR TITLE
feat(subscription): Purchase documents from PACER

### DIFF
--- a/bc/sponsorship/services.py
+++ b/bc/sponsorship/services.py
@@ -1,0 +1,37 @@
+from bc.subscription.models import FilingWebhookEvent
+
+from .models import Sponsorship, Transaction
+
+
+def log_purchase(
+    sponsorship: Sponsorship,
+    filing_webhook_event: FilingWebhookEvent,
+    page_count: int,
+) -> None:
+    """
+    This method adds a new entry in the general ledger (transactions table)
+    after a document has been successfully purchased.
+
+    This method also creates a note for the new entry using data from the docket
+    webhook event and the subscription record.
+
+    Args:
+        sponsorship (Sponsorship): The Sponsorship record used to complete the purchase.
+        filing_webhook_event (FilingWebhookEvent): The docket webhook event related to the document.
+        page_count (int): The number of pages in the PDF file.
+    """
+
+    note = f"Purchase {filing_webhook_event}"
+    if filing_webhook_event.subscription:
+        docket_number = filing_webhook_event.subscription.docket_number
+        court_name = filing_webhook_event.subscription.court_name
+        court_id = filing_webhook_event.subscription.pacer_court_id
+        note += f"({docket_number}) in {court_name}({court_id})"
+
+    Transaction.objects.create(
+        user=sponsorship.user,
+        sponsorship=sponsorship,
+        type=Transaction.DOCUMENT_PURCHASE,
+        amount=3.0 if page_count >= 30 else page_count * 0.10,
+        note=note,
+    )

--- a/bc/sponsorship/signals.py
+++ b/bc/sponsorship/signals.py
@@ -1,7 +1,9 @@
+from django.db import transaction
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 
 from .models import Sponsorship, Transaction
+from .utils import update_sponsorships_current_amount
 
 
 @receiver(post_save, sender=Sponsorship)
@@ -14,4 +16,16 @@ def sponsorship_handler(sender, instance=None, created=False, **kwargs):
             user=instance.user,
             sponsorship=instance,
             amount=instance.original_amount,
+        )
+
+
+@receiver(post_save, sender=Transaction)
+def transaction_handler(sender, instance=None, created=False, **kwargs):
+    if created and instance.type == Transaction.DOCUMENT_PURCHASE:
+        """
+        make sure We update the sponsorship's current_amount only if
+        the django atomic transaction successfully commits.
+        """
+        transaction.on_commit(
+            lambda: update_sponsorships_current_amount(instance)
         )

--- a/bc/sponsorship/signals.py
+++ b/bc/sponsorship/signals.py
@@ -1,4 +1,4 @@
-from django.db import transaction
+from django.db import transaction as db_transaction
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 
@@ -26,6 +26,6 @@ def transaction_handler(sender, instance=None, created=False, **kwargs):
         make sure We update the sponsorship's current_amount only if
         the django atomic transaction successfully commits.
         """
-        transaction.on_commit(
+        db_transaction.on_commit(
             lambda: update_sponsorships_current_amount(instance)
         )

--- a/bc/sponsorship/utils.py
+++ b/bc/sponsorship/utils.py
@@ -1,11 +1,22 @@
 from decimal import Decimal
 
-from .models import Sponsorship, Transaction
+from django.db.models import F
+
+from .models import Transaction
 
 
 def update_sponsorships_current_amount(ledger_entry: Transaction) -> None:
-    if not ledger_entry.sponsorship_id:
+    """
+    This method updates the current_amount field of the sponsorship record
+    related to the given ledger entry after a document has been purchased.
+
+    Args:
+        ledger_entry (Transaction): The transaction object related to the purchase.
+    """
+    if not ledger_entry.sponsorship:
         return None
-    sponsorship = Sponsorship.objects.get(pk=ledger_entry.sponsorship_id)
-    sponsorship.current_amount -= Decimal(ledger_entry.amount)
+    sponsorship = ledger_entry.sponsorship
+    sponsorship.current_amount = F("current_amount") - Decimal(
+        ledger_entry.amount
+    )
     sponsorship.save()

--- a/bc/sponsorship/utils.py
+++ b/bc/sponsorship/utils.py
@@ -1,0 +1,11 @@
+from decimal import Decimal
+
+from .models import Sponsorship, Transaction
+
+
+def update_sponsorships_current_amount(ledger_entry: Transaction) -> None:
+    if not ledger_entry.sponsorship_id:
+        return None
+    sponsorship = Sponsorship.objects.get(pk=ledger_entry.sponsorship_id)
+    sponsorship.current_amount -= Decimal(ledger_entry.amount)
+    sponsorship.save()

--- a/bc/subscription/api_views.py
+++ b/bc/subscription/api_views.py
@@ -10,6 +10,7 @@ from rest_framework.response import Response
 from rq import Retry
 
 from bc.subscription.exceptions import (
+    DocumentFetchFailure,
     IdempotencyKeyMissing,
     WebhookNotSupported,
 )
@@ -87,6 +88,9 @@ def handle_recap_fetch_webhook(request: Request) -> Response:
     data = request.data
     if data["webhook"]["event_type"] != 3:
         raise WebhookNotSupported()
+
+    if data["payload"]["status"] != 2:
+        raise DocumentFetchFailure(data["payload"]["message"])
 
     cache_idempotency_key = cache.get(idempotency_key)
     if cache_idempotency_key:

--- a/bc/subscription/exceptions.py
+++ b/bc/subscription/exceptions.py
@@ -16,3 +16,8 @@ class IdempotencyKeyMissing(BadRequest):
 
 class WebhookNotSupported(BadRequest):
     default_detail = "Webhook type not supported"
+
+
+class DocumentFetchFailure(BadRequest):
+    def __init__(self, detail=None):
+        self.detail = detail

--- a/bc/subscription/tasks.py
+++ b/bc/subscription/tasks.py
@@ -8,8 +8,8 @@ from bc.channel.selectors import get_enabled_channels
 from bc.core.utils.microservices import get_thumbnails_from_range
 from bc.core.utils.status.selectors import get_template_for_channel
 from bc.core.utils.status.templates import DO_NOT_POST
-from bc.sponsorship.models import Transaction
 from bc.sponsorship.selectors import get_active_sponsorship
+from bc.sponsorship.services import log_purchase
 from bc.subscription.utils.courtlistener import (
     download_pdf_from_cl,
     lookup_document_by_doc_id,
@@ -101,13 +101,8 @@ def process_fetch_webhook_event(fwe_pk: int):
 
     sponsorship = get_active_sponsorship()
     if sponsorship:
-        Transaction.objects.create(
-            user=sponsorship.user,
-            sponsorship=sponsorship,
-            type=Transaction.DOCUMENT_PURCHASE,
-            amount=3.0
-            if cl_document["page_count"] >= 30
-            else cl_document["page_count"] * 0.10,
+        log_purchase(
+            sponsorship, filing_webhook_event, cl_document["page_count"]
         )
 
     for channel in get_enabled_channels():

--- a/bc/subscription/tasks.py
+++ b/bc/subscription/tasks.py
@@ -11,7 +11,7 @@ from bc.core.utils.status.templates import DO_NOT_POST
 from bc.sponsorship.models import Transaction
 from bc.sponsorship.selectors import get_active_sponsorship
 from bc.subscription.utils.courtlistener import (
-    get_document_from_CL,
+    download_pdf_from_cl,
     lookup_document_by_doc_id,
     purchase_pdf_by_doc_id,
 )
@@ -61,7 +61,7 @@ def process_filing_webhook_event(fwe_pk: int) -> FilingWebhookEvent:
     document = None
     cl_document = lookup_document_by_doc_id(filing_webhook_event.doc_id)
     if cl_document["filepath_local"]:
-        document = get_document_from_CL(cl_document["filepath_local"])
+        document = download_pdf_from_cl(cl_document["filepath_local"])
     else:
         sponsorship = get_active_sponsorship()
         if sponsorship and filing_webhook_event.pacer_doc_id:
@@ -97,7 +97,7 @@ def process_fetch_webhook_event(fwe_pk: int):
     )
 
     cl_document = lookup_document_by_doc_id(filing_webhook_event.doc_id)
-    document = get_document_from_CL(cl_document["filepath_local"])
+    document = download_pdf_from_cl(cl_document["filepath_local"])
 
     sponsorship = get_active_sponsorship()
     if sponsorship:

--- a/bc/subscription/tasks.py
+++ b/bc/subscription/tasks.py
@@ -1,4 +1,3 @@
-import requests
 from django.conf import settings
 from django.db import transaction
 from django_rq.queues import get_queue
@@ -9,7 +8,12 @@ from bc.channel.selectors import get_enabled_channels
 from bc.core.utils.microservices import get_thumbnails_from_range
 from bc.core.utils.status.selectors import get_template_for_channel
 from bc.core.utils.status.templates import DO_NOT_POST
-from bc.subscription.utils.courtlistener import lookup_document_by_doc_id
+from bc.sponsorship.selectors import get_active_sponsorship
+from bc.subscription.utils.courtlistener import (
+    get_document_from_CL,
+    lookup_document_by_doc_id,
+    purchase_pdf_by_doc_id,
+)
 
 from .models import FilingWebhookEvent, Subscription
 
@@ -53,18 +57,15 @@ def process_filing_webhook_event(fwe_pk: int) -> FilingWebhookEvent:
     if DO_NOT_POST.search(filing_webhook_event.description):
         return filing_webhook_event
 
-    cl_document = lookup_document_by_doc_id(filing_webhook_event.doc_id)
-    document_url = (
-        f"https://storage.courtlistener.com/{cl_document['filepath_local']}"
-        if cl_document["filepath_local"]
-        else None
-    )
-
     document = None
-    if document_url:
-        document_request = requests.get(document_url, timeout=3)
-        document_request.raise_for_status()
-        document = document_request.content
+    cl_document = lookup_document_by_doc_id(filing_webhook_event.doc_id)
+    if cl_document["filepath_local"]:
+        document = get_document_from_CL(cl_document["filepath_local"])
+    else:
+        sponsorship = get_active_sponsorship()
+        if sponsorship and filing_webhook_event.pacer_doc_id:
+            purchase_pdf_by_doc_id(filing_webhook_event.doc_id)
+            return filing_webhook_event
 
     for channel in get_enabled_channels():
         queue.enqueue(

--- a/bc/subscription/urls.py
+++ b/bc/subscription/urls.py
@@ -1,11 +1,16 @@
 from django.urls import path
 
-from .api_views import handle_cl_webhook
+from .api_views import handle_docket_alert_webhook, handle_recap_fetch_webhook
 
 urlpatterns = [
     path(
         "webhooks/docket/",
-        handle_cl_webhook,
-        name="cl_webhook_handler",
+        handle_docket_alert_webhook,
+        name="docket_alert_webhook_handler",
+    ),
+    path(
+        "webhooks/recap-fetch/",
+        handle_recap_fetch_webhook,
+        name="recap_fetch_webhook_handler",
     ),
 ]

--- a/bc/subscription/utils/courtlistener.py
+++ b/bc/subscription/utils/courtlistener.py
@@ -1,4 +1,5 @@
 import logging
+from typing import TypedDict
 
 import courts_db
 import requests
@@ -12,6 +13,8 @@ CL_API = {
     "docket": "https://www.courtlistener.com/api/rest/v3/dockets/",
     "docket-alerts": "https://www.courtlistener.com/api/rest/v3/docket-alerts/",
     "recap-documents": "https://www.courtlistener.com/api/rest/v3/recap-documents/",
+    "recap-fetch": "https://www.courtlistener.com/api/rest/v3/recap-fetch/",
+    "media-storage": "https://storage.courtlistener.com/",
 }
 
 pacer_to_cl_ids = {
@@ -68,19 +71,25 @@ def lookup_docket_by_cl_id(cl_id: int):
     return response.json()
 
 
-def lookup_document_by_doc_id(doc_id: int | None) -> dict[str, str | None]:
+class DocumentDict(TypedDict):
+    page_count: int
+    filepath_local: str
+
+
+def lookup_document_by_doc_id(doc_id: int | None) -> DocumentDict:
     """
     Performs a GET query on /api/rest/v3/recap-documents/
     using the document_id to get a recap document
     """
     response = requests.get(
         f"{CL_API['recap-documents']}{doc_id}/",
-        params={"fields": "filepath_local"},
+        params={"fields": "filepath_local,page_count"},
         headers=auth_header(),
         timeout=5,
     )
     response.raise_for_status()
-    return response.json()
+    data: DocumentDict = response.json()
+    return data
 
 
 def lookup_docket_by_case_number(court: str, docket_number: str):

--- a/bc/subscription/utils/courtlistener.py
+++ b/bc/subscription/utils/courtlistener.py
@@ -92,6 +92,28 @@ def lookup_document_by_doc_id(doc_id: int | None) -> DocumentDict:
     return data
 
 
+def purchase_pdf_by_doc_id(doc_id: int | None) -> int:
+    """
+    Performs a POST query on /api/rest/v3/recap-fetch/
+    using the document_id from CL and the PACER's login
+    credentials.
+    """
+    response = requests.post(
+        f"{CL_API['recap-fetch']}",
+        json={
+            "request_type": 2,
+            "pacer_username": settings.PACER_USERNAME,
+            "pacer_password": settings.PACER_PASSWORD,
+            "recap_document": doc_id,
+        },
+        headers=auth_header(),
+        timeout=5,
+    )
+    response.raise_for_status()
+    data = response.json()
+    return data["id"]
+
+
 def lookup_docket_by_case_number(court: str, docket_number: str):
     """
     Performs a GET query on /api/rest/v3/dockets/

--- a/bc/subscription/utils/courtlistener.py
+++ b/bc/subscription/utils/courtlistener.py
@@ -92,7 +92,7 @@ def lookup_document_by_doc_id(doc_id: int | None) -> DocumentDict:
     return data
 
 
-def get_document_from_CL(filepath: str) -> bytes:
+def download_pdf_from_cl(filepath: str) -> bytes:
     document_url = f"{CL_API['media-storage']}{filepath}"
     document_request = requests.get(document_url, timeout=3)
     document_request.raise_for_status()

--- a/bc/subscription/utils/courtlistener.py
+++ b/bc/subscription/utils/courtlistener.py
@@ -92,6 +92,13 @@ def lookup_document_by_doc_id(doc_id: int | None) -> DocumentDict:
     return data
 
 
+def get_document_from_CL(filepath: str) -> bytes:
+    document_url = f"{CL_API['media-storage']}{filepath}"
+    document_request = requests.get(document_url, timeout=3)
+    document_request.raise_for_status()
+    return document_request.content
+
+
 def purchase_pdf_by_doc_id(doc_id: int | None) -> int:
     """
     Performs a POST query on /api/rest/v3/recap-fetch/


### PR DESCRIPTION
This PR adds logic to automatically purchase documents from PACER and fixes https://github.com/freelawproject/bigcases2/issues/16.

This PR introduces the following changes:

- Add the page_count attribute to the lookup_document request

    This PR tweaks the helper method called `lookup_document_by_doc_id` to add the `page_count` attribute in the response of the CL API and also updates the type hinting of the helper method. We need the `page_count` of the document to compute its price. 

- Adds a helper method to purchase documents using the CL API.
  
    This helper uses the `recap-fetch/` endpoint and the PACER's login credentials to purchase PDFs.

- Adds a helper method to download documents from the RECAP archive.

- Tweaks the helper method called `process_filing_webhook_event` to add the logic to purchase PDF documents if they're not available in the RECAP archive.

- Add a task to handle RECAP fetch webhooks

- Adds a method to handle the transaction's post_save signal. We're using this signal to update the `current_amount` in the `sponsorship` model.



I know the current implementation of the bot is a little hard to fit all in one’s head but the new implementation of the task that handles the docket alert webhooks will work like this (after we add sponsorships and document purchases): 

- The bot gets a docket alert webhook and the main task starts.

- The main task links the webhook to a subscription, checks the webhook description, and tries to retrieve the document. We can have a few scenarios here:

     - If the document is available, The bot downloads it, creates the thumbnails and the main task enters the loop and starts scheduling the subtasks to create the posts.
     
     - If the document is not available but there are sponsorships available, the main task uses the `recap-fetch `endpoint to purchase the PDF and finishes its execution ( The bot will use the RECAP fetch webhook to create the posts)
    
     - if the document is not available and there's no sponsorship available, the main task enters the loop and starts scheduling the subtasks to create the post without thumbnails.