### PR TITLE
feat(templates): Add explicit width and height to img elements

### DIFF
--- a/bc/assets/templates/includes/footer.html
+++ b/bc/assets/templates/includes/footer.html
@@ -4,7 +4,7 @@
     <div class="max-w-3xl  lg:max-w-7xl mx-auto px-4 sm:px-6 md:px-10">
         <section id="footer" class="flex w-full py-8 justify-start lg:justify-between">
           <div class="w-1/5 hidden lg:block">
-            <img alt='Yellow robot logo' src="{% static "svg/icon.svg" %}"  layout="responsive" class="rounded-lg border-4 border-gray-700 h-24 lg:h-28 xl:h-36 bg-white"/>
+            <img alt='Yellow robot logo' src="{% static "svg/icon.svg" %}"  layout="responsive" class="rounded-lg border-4 border-gray-700 h-24 lg:h-28 xl:h-36 xl:w-[142px] bg-white"/>
           </div>
 
           <div class="w-full xl:w-4/5">

--- a/bc/assets/templates/includes/header.html
+++ b/bc/assets/templates/includes/header.html
@@ -5,7 +5,7 @@
         <div class="flex w-full justify-between items-center py-6 md:space-x-6 lg:space-x-10">
             <div class="absolute top-6">
                 <a href="{% url 'homepage' %}">
-                    <img alt='Yellow robot with white background logo' src="{% static "svg/icon.svg" %}"  layout="responsive" class="rounded-lg border-4 border-bcb-black h-20 lg:h-24 bg-white"/>
+                    <img alt='Yellow robot with white background logo' src="{% static "svg/icon.svg" %}"  layout="responsive" class="rounded-lg border-4 border-bcb-black h-20 w-[80px] lg:h-24 lg:w-24 bg-white"/>
                 </a>
             </div>
 

--- a/bc/web/templates/homepage.html
+++ b/bc/web/templates/homepage.html
@@ -9,7 +9,7 @@
             <h1 class="md:max-w-md xl:max-w-xl font-[800] text-5xl md:text-6xl lg:text-6xl xl:text-7xl text-left">
                 Hi! I’m the bot that keeps you updated about court cases!
             </h1>
-            <img alt='Full body robot holding a gavel' src="{% static "svg/full-body-left-hand.svg" %}" class="hidden sm:block w-32 sm:w-56 md:w-80 lg:w-96 xl:w-[500px]">
+            <img alt='Full body robot holding a gavel' src="{% static "svg/full-body-left-hand.svg" %}" class="hidden sm:block w-32 sm:w-56 md:w-80 lg:w-96 xl:w-[500px] xl:h-[550px]">
         </div>
 
     </div>
@@ -20,7 +20,7 @@
         <div class="py-8 md:py-16 text-white">
             <div class="grid grid-cols-2 flex flex-col justify-center gap-10 pt-6">
                 <div class="flex justify-start self-start">
-                    <img alt='logos for popular chat applications, including Slack, Discord, Microsoft Teams and Google Chat' src="{% static "svg/chat-app-logos-combined.svg" %}" class="w-48 object-contain sm:w-64 md:w-72 lg:w-80 xl:w-[490px] xl:h-[440px]">
+                    <img alt='logos for popular chat applications, including Slack, Discord, Microsoft Teams and Google Chat' src="{% static "svg/chat-app-logos-combined.svg" %}" class="w-48 h-[172px] object-contain sm:w-64 sm:h-[230px] md:w-72 md:h-[259px] lg:w-80 lg:h-[288px] xl:w-[490px] xl:h-[440px]">
                 </div>
                 <div class="flex w-full justify-center">
                     <div class="md:max-w-sm lg:max-w-lg flex flex-col">
@@ -71,11 +71,11 @@
             </div>
 
             <div class="w-full hidden md:flex mx-auto justify-center items-center">
-                <img alt='The FLP logo' src="{% static "svg/free-law-banner.svg" %}"  layout="responsive" class="w-68 object-contain hidden md:block md:w-15"/>
+                <img alt='The FLP logo' src="{% static "svg/free-law-banner.svg" %}"  layout="responsive" class="object-contain hidden md:block md:w-15 lg:h-[200px] lg:w-[600px]"/>
             </div>
 
             <div class="w-full flex justify-center md:hidden row-span-1 align-center items-center">
-                <img alt='The FLP logo' src="{% static "svg/free-law-icon.svg" %}"  layout="responsive" class="h-40"/>
+                <img alt='The FLP logo' src="{% static "svg/free-law-icon.svg" %}"  layout="responsive" class="h-40 w-[172px]"/>
             </div>
         </section>
         <div class="flex sm:hidden w-full pt-4 flex-col text-md md:text-lg lg:text-2xl font-light">


### PR DESCRIPTION
This PR adds the `height` and `width` properties to the image elements in the HTML templates. These properties fix the following issue from the [PageSpeed report](https://pagespeed.web.dev/analysis/https-bots-law/gzo5arnl2a):

- Image elements do not have explicit width and height.