### PR TITLE
fix(core): Check the max number of characters before updating its value.

### DIFF
--- a/bc/core/utils/images.py
+++ b/bc/core/utils/images.py
@@ -131,8 +131,14 @@ class TextImage:
             increment = (
                 self.get_available_space(wrapped_desc) / reference_length
             )
+            wrapped_desc = wrap(
+                self.description, max_character + ceil(increment)
+            )
+
+            # check if the new max number of characters won't overflow the rectangle
+            if self.get_available_space(wrapped_desc) <= 0:
+                break
             max_character += ceil(increment)
-            wrapped_desc = wrap(self.description, max_character)
 
         return max_character
 


### PR DESCRIPTION
This PR tweaks the method called `get_max_character_count` in the `TextImage` class and fixes the overflow in images like the one attached to this tweet:

https://twitter.com/big_cases/status/1644518874774388737


In the previous tweet, We see that the text in the first image overflows the rectangle. This issue happened because We use a `while` loop to increase the maximum number of characters that should be rendered per line but the current implementation of the logic inside the loop updates the value of the `max_character` variable without checking if the new value allows us to render the text without overflowing the image

This commit adds an if statement to check the new value for the `max_character` variable before updating it.

Here's a post using new logic and the same case that has the image with overflow:

https://twitter.com/flp_tests/status/1644534045500485632