### PR TITLE
feat(user): Enhance admin site for the User model

### DIFF
--- a/bc/users/admin.py
+++ b/bc/users/admin.py
@@ -1,5 +1,17 @@
 from django.contrib import admin
+from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
 
 from .models import User
 
-admin.site.register(User)
+
+class UserAdmin(BaseUserAdmin):
+    fieldsets = BaseUserAdmin.fieldsets + (  # type: ignore
+        # Custom fields added on to the bottom
+        ("Extra Fields", {"fields": ["affiliation"]}),
+    )
+    add_fieldsets = (
+        (None, {"classes": ["wide"], "fields": ["email"]}),
+    ) + BaseUserAdmin.add_fieldsets
+
+
+admin.site.register(User, UserAdmin)


### PR DESCRIPTION
This PR enhances the django admin interface for the `User` model by extending the `django.contrib.auth.admin.UserAdmin` class.

Django uses the `UserAdmin` class to render a nice-looking admin site for the `User` model. By just using this class in our `admin.py` file, we can get the same look for our model.  

The `UserAdmin` provides a custom **form** to create users from the admin panel(uses the [user/add_form.html ](https://github.com/django/django/blob/8b1ff0da4b162e87edebd94e61f2cd153e9e159d/django/contrib/admin/templates/admin/auth/user/add_form.html) file to render the form after clicking the `add user` button in the admin site) and We can customize the **fields** included in the form (like this PR does in line 12 of the admin.py file). This class will also take care of password validation and hashing. 

The form to add users from the admin panel looks like this:
 
![image](https://user-images.githubusercontent.com/55959657/232943207-9769e0c4-afd7-4c38-80f1-c1d968ef17f3.png)

However, this alone is not enough, since Django Admin will not display any of the customs fields from the User model when editing users, so We also need to tweak the `fieldsets` variable.

This enhancement will help us create users for curators(https://github.com/freelawproject/bigcases2/issues/24) and sponsors(https://github.com/freelawproject/bigcases2/issues/152) using a clean form in the admin site.
