### PR TITLE
feat(core): Add a regex expression to filter documents to purchase

### DIFF
--- a/bc/core/utils/status/templates.py
+++ b/bc/core/utils/status/templates.py
@@ -14,6 +14,15 @@ DO_NOT_POST = re.compile(
     re.VERBOSE | re.IGNORECASE,
 )
 
+DO_NOT_PAY = re.compile(
+    r"""(
+    withdraw\sas\sattorney|         # withdraw as attorney
+    summons\s.*\sexecuted|          # summons .* executed
+    none
+    )""",
+    re.VERBOSE | re.IGNORECASE,
+)
+
 MASTODON_POST_TEMPLATE = MastodonTemplate(
     link_placeholders=["pdf_link", "docket_link"],
     str_template="""New filing: "{docket}"

--- a/bc/sponsorship/admin.py
+++ b/bc/sponsorship/admin.py
@@ -9,4 +9,6 @@ class SponsorshipAdmin(admin.ModelAdmin):
     exclude = ("current_amount",)
 
 
-admin.site.register(Transaction)
+@admin.register(Transaction)
+class TransactionAdmin(admin.ModelAdmin):
+    list_display = ("__str__", "type", "amount")

--- a/bc/subscription/tasks.py
+++ b/bc/subscription/tasks.py
@@ -8,7 +8,7 @@ from bc.channel.selectors import get_enabled_channels
 from bc.core.utils.images import add_sponsored_text_to_thumbnails
 from bc.core.utils.microservices import get_thumbnails_from_range
 from bc.core.utils.status.selectors import get_template_for_channel
-from bc.core.utils.status.templates import DO_NOT_POST
+from bc.core.utils.status.templates import DO_NOT_PAY, DO_NOT_POST
 from bc.sponsorship.selectors import get_active_sponsorship
 from bc.sponsorship.services import log_purchase
 from bc.subscription.utils.courtlistener import (
@@ -92,7 +92,11 @@ def check_webhook_before_posting(fwe_pk: int):
         document = download_pdf_from_cl(cl_document["filepath_local"])
     else:
         sponsorship = get_active_sponsorship()
-        if sponsorship and filing_webhook_event.pacer_doc_id:
+        if (
+            sponsorship
+            and filing_webhook_event.pacer_doc_id
+            and not DO_NOT_PAY.search(filing_webhook_event.description)
+        ):
             purchase_pdf_by_doc_id(filing_webhook_event.doc_id)
             filing_webhook_event.status = (
                 FilingWebhookEvent.WAITING_FOR_DOCUMENT


### PR DESCRIPTION
This PR adds a regex expression to filter documents the Bot should purchase and also tweaks the admin site for the `Transaction` model