### PR TITLE
feat(core): Add hashtags to the mastodon templates

### DIFF
--- a/bc/core/utils/status/templates.py
+++ b/bc/core/utils/status/templates.py
@@ -29,7 +29,9 @@ MASTODON_POST_TEMPLATE = MastodonTemplate(
 Doc #{doc_num}: {description}
 
 PDF: {pdf_link}
-Docket: {docket_link}""",
+Docket: {docket_link}
+
+#CL{docket_id}""",
 )
 
 
@@ -37,7 +39,9 @@ MASTODON_MINUTE_TEMPLATE = MastodonTemplate(
     link_placeholders=["docket_link"],
     str_template="""New minute entry in {docket}: {description}
 
-Docket: {docket_link}""",
+Docket: {docket_link}
+
+#CL{docket_id}""",
 )
 
 TWITTER_POST_TEMPLATE = TwitterTemplate(

--- a/bc/subscription/tasks.py
+++ b/bc/subscription/tasks.py
@@ -208,6 +208,7 @@ def make_post_for_webhook_event(
         doc_num=filing_webhook_event.document_number,
         pdf_link=filing_webhook_event.cl_pdf_or_pacer_url,
         docket_link=filing_webhook_event.cl_docket_url,
+        docket_id=filing_webhook_event.docket_id,
     )
 
     files = None


### PR DESCRIPTION
This PR adds a hashtag to the mastodon templates and fixes https://github.com/freelawproject/bigcases2/issues/196.

Here are screenshots of posts created with the new template:

![image](https://user-images.githubusercontent.com/55959657/234438200-5a43e25d-160a-43c6-855a-d62dfab17b7d.png)


![image](https://user-images.githubusercontent.com/55959657/234438234-dd186675-7dec-45b3-beb4-b43ba16a28a6.png)
