### PR TITLE
feat(subscription): Add the attachment number to the templates

### DIFF
--- a/bc/subscription/models.py
+++ b/bc/subscription/models.py
@@ -190,6 +190,12 @@ class FilingWebhookEvent(AbstractDateTimeModel):
         ]
 
     @property
+    def document_number_with_attachment(self) -> str:
+        if self.attachment_number:
+            return f"{self.document_number}-{self.attachment_number}"
+        return f"{self.document_number}"
+
+    @property
     def cl_document_url(self) -> str | None:
         if not self.subscription:
             return None

--- a/bc/subscription/tasks.py
+++ b/bc/subscription/tasks.py
@@ -205,7 +205,7 @@ def make_post_for_webhook_event(
     message, image = template.format(
         docket=subscription.name_with_summary,
         description=filing_webhook_event.description,
-        doc_num=filing_webhook_event.document_number,
+        doc_num=filing_webhook_event.document_number_with_attachment,
         pdf_link=filing_webhook_event.cl_pdf_or_pacer_url,
         docket_link=filing_webhook_event.cl_docket_url,
         docket_id=filing_webhook_event.docket_id,


### PR DESCRIPTION
This PR adds a new property to the `FilingWebhookEvent` model. This new property allows us to use the attachment number (if available) in the post templates.


