### PR TITLE
fix(template): Remove inline elements from the add case template

### DIFF
--- a/bc/assets/static-global/js/fix-toolbar-for-htmx.js
+++ b/bc/assets/static-global/js/fix-toolbar-for-htmx.js
@@ -1,0 +1,10 @@
+if (typeof window.htmx !== "undefined") {
+  htmx.on("htmx:afterSettle", function(detail) {
+      if (
+          typeof window.djdt !== "undefined"
+          && detail.target instanceof HTMLBodyElement
+      ) {
+          djdt.show_toolbar();
+      }
+  });
+}

--- a/bc/assets/templates/base.html
+++ b/bc/assets/templates/base.html
@@ -9,6 +9,7 @@
     <meta name="language" content="en_us"/>
     <meta name="viewport" content="width=device-width,initial-scale=1"/>
     <meta name="description" content="Use Bots.law to get court alerts in Slack, Discord, MS Teams, Twitter, Mastodon, and Google Chat. Home of the Big Cases bots."/>
+    <meta name="htmx-config" content='{"includeIndicatorStyles":false}'>
 
     <title>{% block title %}{% endblock %} — Bots.law</title>
     {% endblock %}

--- a/bc/subscription/templates/add-case.html
+++ b/bc/subscription/templates/add-case.html
@@ -4,24 +4,11 @@
 {% block footer-scripts %}
   {% if debug %}
     <script src="{% static "js/htmx.js" %}"></script>
+    <script src="{% static "js/fix-toolbar-for-htmx.js" %}"></script>
   {% else %}
     <script src="{% static "js/htmx.min.js" %}"></script>
   {% endif %}
   <script src="{% static "js/loading-states.js" %}"></script>
-  {% if debug %}
-  <script>
-    if (typeof window.htmx !== "undefined") {
-      htmx.on("htmx:afterSettle", function(detail) {
-          if (
-              typeof window.djdt !== "undefined"
-              && detail.target instanceof HTMLBodyElement
-          ) {
-              djdt.show_toolbar();
-          }
-      });
-    }
-  </script>
-  {% endif %}
 {% endblock %}
 
 {% block title %}Add a new case{% endblock %}

--- a/bc/web/static_src/src/styles.css
+++ b/bc/web/static_src/src/styles.css
@@ -17,6 +17,9 @@
   [data-loading] {
     display: none;
   }
+  .htmx-indicator{opacity:0;transition: opacity 200ms ease-in;}
+  .htmx-request .htmx-indicator{opacity:1}
+  .htmx-request.htmx-indicator{opacity:1}
 }
 
 @font-face {


### PR DESCRIPTION
This PR fixes the errors with the CSP policies of the website caused by the inline elements in the `add-case` template.

This PR introduces the following changes:

- Adds a meta tag to tweak the configuration options of HTMX and avoid injecting inline styles. I used the comments from [CSP issue: style-insertion]( https://github.com/bigskysoftware/htmx/issues/862) to find the option that We should change. 
- Move the js code suggested on the `debug toolbar` docs into an asset to avoid inline scripts in the `add-case.html` template.