### PR TITLE
feat(web): Tweak logic related to subscriptions. 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,25 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
-
+    env:
+      DB_USER: postgres
+      DB_PASSWORD: postgres
+      DB_NAME: bots
+      DB_HOST: localhost
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_USER: ${{ env.DB_USER }}
+          POSTGRES_PASSWORD: ${{ env.DB_PASSWORD }}
+          POSTGRES_DB: ${{ env.DB_NAME }}
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python 3.11

--- a/bc/assets/static-global/js/checkbox-group.js
+++ b/bc/assets/static-global/js/checkbox-group.js
@@ -1,10 +1,11 @@
 
 var CheckboxGroup =  (function () {
-  function CheckboxGroup(targetElement, triggerElement) {
+  function CheckboxGroup(targetElement, triggerElement, removeCheckElement) {
       if (targetElement === void 0) { targetElement = null; }
       if (triggerElement === void 0) { triggerElement = null; }
       this._targetEl = targetElement;
       this._triggerEl = triggerElement;
+      this._removeCheck = removeCheckElement;
       this._checked = true;
       this._init();
   }
@@ -16,7 +17,10 @@ var CheckboxGroup =  (function () {
   CheckboxGroup.prototype._setupEventListeners = function () {
     var _this = this;
     this._triggerEl.addEventListener('click', function () {
-        _this.toggle();
+      _this.check();
+    });
+    this._removeCheck.addEventListener('click', function () {
+      _this.uncheck();
     });
   };
   CheckboxGroup.prototype.toggle = function () {
@@ -48,9 +52,11 @@ function initCheckboxes() {
       .querySelectorAll('[data-cg-target]')
       .forEach(function ($triggerEl) {
       var targetClass = $triggerEl.getAttribute('data-cg-target');
+      var noneButtonId = $triggerEl.getAttribute('data-cg-uncheck');
+      var removeCheckButton = document.getElementById(noneButtonId)
       var $groupEl = document.querySelectorAll(`.${targetClass}`);
       if ($groupEl) {
-        new CheckboxGroup($groupEl, $triggerEl);
+        new CheckboxGroup($groupEl, $triggerEl, removeCheckButton);
       }
       else {
           console.error("The checkbox element with id \"".concat(targetClass, "\" does not exist. Please check the data-cg-toggle attribute."));

--- a/bc/assets/static-global/js/checkbox-group.js
+++ b/bc/assets/static-global/js/checkbox-group.js
@@ -1,0 +1,63 @@
+
+var CheckboxGroup =  (function () {
+  function CheckboxGroup(targetElement, triggerElement) {
+      if (targetElement === void 0) { targetElement = null; }
+      if (triggerElement === void 0) { triggerElement = null; }
+      this._targetEl = targetElement;
+      this._triggerEl = triggerElement;
+      this._checked = true;
+      this._init();
+  }
+  CheckboxGroup.prototype._init = function () {
+    if (this._triggerEl) {
+        this._setupEventListeners();
+    }
+  };
+  CheckboxGroup.prototype._setupEventListeners = function () {
+    var _this = this;
+    this._triggerEl.addEventListener('click', function () {
+        _this.toggle();
+    });
+  };
+  CheckboxGroup.prototype.toggle = function () {
+    if (this._checked) {
+      this.uncheck();
+    }
+    else {
+      this.check();
+    }
+  };
+  CheckboxGroup.prototype.check = function () {
+    this._targetEl.forEach(function ($checkbox) {
+      $checkbox.checked = true;
+    })
+    this._checked = true;
+  };
+  CheckboxGroup.prototype.uncheck = function () {
+    this._targetEl.forEach(function ($checkbox) {
+      $checkbox.checked = false;
+    })
+    this._checked = false;
+  };
+  return CheckboxGroup;
+}());
+
+
+function initCheckboxes() {
+  document
+      .querySelectorAll('[data-cg-target]')
+      .forEach(function ($triggerEl) {
+      var targetClass = $triggerEl.getAttribute('data-cg-target');
+      var $groupEl = document.querySelectorAll(`.${targetClass}`);
+      if ($groupEl) {
+        new CheckboxGroup($groupEl, $triggerEl);
+      }
+      else {
+          console.error("The checkbox element with id \"".concat(targetClass, "\" does not exist. Please check the data-cg-toggle attribute."));
+      }
+  });
+}
+
+document.body.addEventListener("groupCheckbox", function(evt){
+  initCheckboxes()
+})

--- a/bc/channel/management/commands/post.py
+++ b/bc/channel/management/commands/post.py
@@ -15,6 +15,18 @@ queue = get_queue("default")
 def handle_post_command(
     ids: list[int], mapping: dict[int, Channel | Group], text: str
 ) -> None:
+    """
+    Enqueues a job to create a post for each channel in the list of ids provided
+    by the user.
+
+    Args:
+        ids (list[int]): list of the id from the user's input.
+        mapping (dict[int, Channel  |  Group]): Mapping of objects in the table.
+        text (str): Text to include in the posts.
+
+    Raises:
+        ValueError: if the provided input is not in the mapping variable.
+    """
     for record_id in ids:
         record = mapping.get(record_id)
 

--- a/bc/channel/management/commands/post.py
+++ b/bc/channel/management/commands/post.py
@@ -1,48 +1,82 @@
+from django.conf import settings
 from django.core.management.base import BaseCommand
-from prettytable import PrettyTable
+from django_rq.queues import get_queue
+from rq import Retry
 
-from bc.channel.models import Channel
-from bc.channel.utils.connectors.masto import MastodonConnector
-from bc.channel.utils.connectors.twitter import TwitterConnector
+from bc.channel.models import Channel, Group
+from bc.core.utils.commands import (
+    show_all_channels_table,
+    show_channel_groups_table,
+)
+
+queue = get_queue("default")
+
+
+def handle_post_command(
+    ids: list[int], mapping: dict[int, Channel | Group], text: str
+) -> None:
+    for record_id in ids:
+        record = mapping.get(record_id)
+
+        if record is None:
+            raise ValueError(f"No channel {record_id}")
+
+        if isinstance(record, Group):
+            for channel in record.channels.all():
+                api = channel.get_api_wrapper()
+                queue.enqueue(
+                    api.add_status,
+                    text,
+                    None,
+                    retry=Retry(
+                        max=settings.RQ_MAX_NUMBER_OF_RETRIES,
+                        interval=settings.RQ_RETRY_INTERVAL,
+                    ),
+                )
+        else:
+            api = record.get_api_wrapper()
+            queue.enqueue(
+                api.add_status,
+                text,
+                None,
+                retry=Retry(
+                    max=settings.RQ_MAX_NUMBER_OF_RETRIES,
+                    interval=settings.RQ_RETRY_INTERVAL,
+                ),
+            )
 
 
 class Command(BaseCommand):
     help = "Post something manually to one or more channels."
 
-    def handle(self, *args, **options):
-        tab = PrettyTable()
-        channel_mapping = {}
-        tab.field_names = ["ID", "Service", "Account", "Enabled", "URL"]
-        db_channels = Channel.objects.all()
-        for channel in db_channels:
-            tab.add_row(
-                [
-                    channel.id,
-                    channel.service,
-                    channel.account,
-                    channel.enabled,
-                    channel.self_url(),
-                ]
-            )
-            channel_mapping[channel.id] = channel
-        self.stdout.write(self.style.SUCCESS(tab))
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--show_groups",
+            action="store_true",
+            help="Shows the list of groups instead of individual channels",
+        )
 
-        channel_input = input(
-            "Which channels? Input ID, comma-separate for multiple, "
+    def handle(self, *args, **options):
+        if not options["show_groups"]:
+            table, mapping = show_all_channels_table()
+        else:
+            table, mapping = show_channel_groups_table()
+
+        self.stdout.write(self.style.SUCCESS(table))
+
+        instance = "group" if options["show_groups"] else "channel"
+
+        ch_input = input(
+            f"Which {instance}? Input ID, comma-separate for multiple, "
             "or 'all' for all of them.\n"
         )
-        self.stdout.write(self.style.SUCCESS(channel_input))
 
-        if channel_input == "all":
-            channel_ids = list(channel_mapping.keys())
+        if ch_input == "all":
+            input_ids = list(mapping.keys())
         else:
-            channel_ids = list(
-                map(int, [s.strip() for s in channel_input.split(",")])
+            input_ids = list(
+                map(int, [s.strip() for s in ch_input.split(",")])
             )
-
-        self.stdout.write(
-            self.style.SUCCESS(f"Posting to channels: {channel_ids}")
-        )
 
         post_text = input("What do you want to say? ")
 
@@ -52,31 +86,4 @@ class Command(BaseCommand):
             )
         )
 
-        for channel_id in channel_ids:
-            channel = channel_mapping.get(channel_id)
-            if channel is None:
-                raise ValueError(f"No channel {channel_id}")
-
-            match channel.service:
-                case Channel.MASTODON:
-                    self.stdout.write(
-                        self.style.SUCCESS(
-                            f"Let's toot from {channel.account}!"
-                        )
-                    )
-
-                    m = MastodonConnector()
-                    m.add_status(post_text)
-                case Channel.TWITTER:
-                    self.stdout.write(
-                        self.style.SUCCESS(
-                            f"Let's tweet from {channel.account}!"
-                        )
-                    )
-
-                    api = TwitterConnector()
-                    api.add_status(post_text)
-                case _:
-                    raise NotImplementedError(
-                        f"Not posting to {channel.service} yet"
-                    )
+        handle_post_command(input_ids, mapping, post_text)

--- a/bc/channel/management/commands/post.py
+++ b/bc/channel/management/commands/post.py
@@ -63,20 +63,20 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument(
-            "--show_groups",
+            "--show_channels",
             action="store_true",
-            help="Shows the list of groups instead of individual channels",
+            help="Shows the list of individual channels",
         )
 
     def handle(self, *args, **options):
-        if not options["show_groups"]:
-            table, mapping = show_all_channels_table()
-        else:
+        if not options["show_channels"]:
             table, mapping = show_channel_groups_table()
+        else:
+            table, mapping = show_all_channels_table()
 
         self.stdout.write(self.style.SUCCESS(table))
 
-        instance = "group" if options["show_groups"] else "channel"
+        instance = "channel" if options["show_channels"] else "group"
 
         ch_input = input(
             f"Which {instance}? Input ID, comma-separate for multiple, "

--- a/bc/channel/selectors.py
+++ b/bc/channel/selectors.py
@@ -1,4 +1,4 @@
-from collections.abc import Iterable
+from django.db.models import QuerySet
 
 from django.conf import settings
 from django.db.models import Prefetch
@@ -18,29 +18,29 @@ def get_mastodon_channel() -> Channel:
     return obj
 
 
-def get_all_enabled_channels() -> Iterable[Channel]:
+def get_all_enabled_channels() -> QuerySet[Channel]:
     """
     Returns the set of all enabled channels.
 
     Returns:
-        Iterable[Channel]: Set of channels
+        QuerySet[Channel]: Set of channels
     """
     return Channel.objects.filter(enabled=True).all()
 
 
-def get_channels_per_subscription(subscription_pk: int) -> Iterable[Channel]:
+def get_channels_per_subscription(subscription_pk: int) -> QuerySet[Channel]:
     """
     Returns the set of all enabled channels linked to a subscription
 
     Returns:
-        Iterable[Channel]: Set of channels
+        QuerySet[Channel]: Set of channels
     """
     return Channel.objects.filter(
         enabled=True, subscriptions__in=[subscription_pk]
     ).all()
 
 
-def get_channel_groups_per_user(user_pk: int) -> Iterable[Group]:
+def get_channel_groups_per_user(user_pk: int) -> QuerySet[Group]:
     """
     Returns the list of groups that contains channels related to a user.
 
@@ -48,7 +48,7 @@ def get_channel_groups_per_user(user_pk: int) -> Iterable[Group]:
         user_pk (int): the pk of the user record
 
     Returns:
-        Iterable[Channel]: Set of groups
+        QuerySet[Channel]: Set of groups
     """
     return (
         Group.objects.filter(  # filter the list of groups

--- a/bc/channel/selectors.py
+++ b/bc/channel/selectors.py
@@ -54,6 +54,7 @@ def get_channel_groups_per_user(user_pk: int) -> Iterable[Group]:
         Group.objects.filter(  # filter the list of groups
             channels__user__in=[user_pk]
         )
+        .distinct("id")
         .prefetch_related(
             Prefetch(  # retrieve only channels related to the active user
                 "channels", queryset=Channel.objects.filter(user__in=[user_pk])

--- a/bc/channel/selectors.py
+++ b/bc/channel/selectors.py
@@ -17,5 +17,10 @@ def get_mastodon_channel() -> Channel:
     return obj
 
 
-def get_enabled_channels() -> Iterable[Channel]:
+def get_all_enabled_channels() -> Iterable[Channel]:
+    """Returns the set of all enabled channels.
+
+    Returns:
+        Iterable[Channel]: Set of channels
+    """
     return Channel.objects.filter(enabled=True).all()

--- a/bc/channel/selectors.py
+++ b/bc/channel/selectors.py
@@ -1,7 +1,5 @@
-from django.db.models import QuerySet
-
 from django.conf import settings
-from django.db.models import Prefetch
+from django.db.models import Prefetch, QuerySet
 
 from .models import Channel, Group
 

--- a/bc/channel/selectors.py
+++ b/bc/channel/selectors.py
@@ -18,9 +18,22 @@ def get_mastodon_channel() -> Channel:
 
 
 def get_all_enabled_channels() -> Iterable[Channel]:
-    """Returns the set of all enabled channels.
+    """
+    Returns the set of all enabled channels.
 
     Returns:
         Iterable[Channel]: Set of channels
     """
     return Channel.objects.filter(enabled=True).all()
+
+
+def get_channels_per_subscription(subscription_pk: int) -> Iterable[Channel]:
+    """
+    Returns the set of all enabled channels linked to a subscription
+
+    Returns:
+        Iterable[Channel]: Set of channels
+    """
+    return Channel.objects.filter(
+        enabled=True, subscriptions__in=[subscription_pk]
+    ).all()

--- a/bc/channel/tasks.py
+++ b/bc/channel/tasks.py
@@ -1,0 +1,40 @@
+from django.conf import settings
+from django_rq.queues import get_queue
+from rq import Retry
+
+from .models import Channel, Group
+
+queue = get_queue("default")
+
+
+def enqueue_text_status_for_channel(channel: Channel, text: str) -> None:
+    """
+    Enqueue a job to create a new status with only text in the given
+    channel.
+
+    Args:
+        channel (Channel): The channel object.
+        text (str): Message for the new status.
+    """
+    api = channel.get_api_wrapper()
+    queue.enqueue(
+        api.add_status,
+        text,
+        retry=Retry(
+            max=settings.RQ_MAX_NUMBER_OF_RETRIES,
+            interval=settings.RQ_RETRY_INTERVAL,
+        ),
+    )
+
+
+def enqueue_text_status_for_group(group: Group, text: str) -> None:
+    """
+    Enqueue a job to create a new status in each channel linked to the
+    given group.
+
+    Args:
+        group (Group): The given group.
+        text (str): Message for the post.
+    """
+    for channel in group.channels.all():
+        enqueue_text_status_for_channel(channel, text)

--- a/bc/channel/tests/factories.py
+++ b/bc/channel/tests/factories.py
@@ -1,0 +1,18 @@
+from factory import SubFactory
+from factory.django import DjangoModelFactory
+from factory.fuzzy import FuzzyChoice
+
+from bc.channel.models import Channel, Group
+
+
+class GroupFactory(DjangoModelFactory):
+    class Meta:
+        model = Group
+
+
+class ChannelFactory(DjangoModelFactory):
+    class Meta:
+        model = Channel
+
+    service = FuzzyChoice(Channel.CHANNELS, getter=lambda c: c[0])
+    group = SubFactory(GroupFactory)

--- a/bc/channel/tests/test_selectors.py
+++ b/bc/channel/tests/test_selectors.py
@@ -1,0 +1,73 @@
+from django.test import TestCase
+
+from bc.channel.selectors import (
+    get_all_enabled_channels,
+    get_channel_groups_per_user,
+    get_channels_per_subscription,
+)
+from bc.subscription.tests.factories import SubscriptionFactory
+from bc.users.tests.factories import UserFactory
+
+from .factories import ChannelFactory, GroupFactory
+
+
+class GetAllEnabledChannels(TestCase):
+    @classmethod
+    def setUpTestData(cls) -> None:
+        # Create a few disable channels
+        ChannelFactory.create_batch(4)
+
+        # Create enabled channels
+        ChannelFactory.create_batch(2, enabled=True)
+
+    def test_can_get_list_of_enable_channels(self):
+        channels = get_all_enabled_channels()
+        self.assertEqual(channels.count(), 2)
+
+
+class GetChannelsPerSubscription(TestCase):
+    subscription = None
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        # Create a few active channels
+        ChannelFactory.create_batch(4, enabled=True)
+        # Channels for the subscription
+        channels_for_subscription = ChannelFactory.create_batch(
+            10, enabled=True
+        )
+        cls.subscription = SubscriptionFactory(
+            channels=channels_for_subscription
+        )
+
+    def test_can_get_enable_channels_linked_to_subscription(self):
+        channels = get_channels_per_subscription(self.subscription.pk)
+        self.assertEqual(channels.count(), 10)
+
+
+class GetChannelGroupsPerUser(TestCase):
+    user = None
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        # create 2 groups of channels
+        group_1 = GroupFactory()
+        group_2 = GroupFactory()
+
+        # Link groups to a few channels
+        channels_g1 = ChannelFactory.create_batch(2, group=group_1)
+        channels_g2 = ChannelFactory.create_batch(3, group=group_2)
+
+        # create more groups of channels
+        ChannelFactory.create_batch(6)
+
+        # link the first channel from two of the groups to the user object
+        cls.user = UserFactory(channels=[channels_g1[0], channels_g2[0]])
+
+    def test_can_get_groups_linked_to_users(self):
+        groups = get_channel_groups_per_user(self.user.pk)
+        # check the number of groups
+        self.assertEqual(groups.count(), 2)
+        for group in groups:
+            # check the number of channels per group
+            self.assertEqual(group.channels.count(), 1)

--- a/bc/channel/utils/connectors/base.py
+++ b/bc/channel/utils/connectors/base.py
@@ -45,8 +45,8 @@ class BaseAPIConnector(Protocol):
     def add_status(
         self,
         message: str,
-        text_image: TextImage | None,
-        thumbnails: list[bytes] | None,
+        text_image: TextImage | None = None,
+        thumbnails: list[bytes] | None = None,
     ) -> int:
         """
         Creates a new status using the API wrapper object and returns the integer

--- a/bc/core/utils/commands.py
+++ b/bc/core/utils/commands.py
@@ -1,6 +1,7 @@
 from prettytable import PrettyTable
 
 from bc.channel.models import Channel, Group
+from bc.channel.selectors import get_all_enabled_channels
 
 
 def show_all_channels_table() -> tuple[PrettyTable, dict[int, Channel]]:
@@ -13,8 +14,7 @@ def show_all_channels_table() -> tuple[PrettyTable, dict[int, Channel]]:
     table = PrettyTable()
     mapping = {}
     table.field_names = ["ID", "Service", "Account", "Enabled", "URL", "Group"]
-    db_channels = Channel.objects.all()
-    for channel in db_channels:
+    for channel in get_all_enabled_channels():
         table.add_row(
             [
                 channel.id,

--- a/bc/core/utils/commands.py
+++ b/bc/core/utils/commands.py
@@ -18,7 +18,7 @@ def show_all_channels_table() -> tuple[PrettyTable, dict[int, Channel]]:
         table.add_row(
             [
                 channel.id,
-                channel.service,
+                channel.get_service_display(),
                 channel.account,
                 channel.enabled,
                 channel.self_url(),

--- a/bc/core/utils/commands.py
+++ b/bc/core/utils/commands.py
@@ -1,0 +1,59 @@
+from prettytable import PrettyTable
+
+from bc.channel.models import Channel, Group
+
+
+def show_all_channels_table() -> tuple[PrettyTable, dict[int, Channel]]:
+    """
+    Builds a table to show the list of enabled channels
+
+    Returns:
+        tuple[PrettyTable, dict[int,Channel]]: returns the table and a dict with the data as a tuple
+    """
+    table = PrettyTable()
+    mapping = {}
+    table.field_names = ["ID", "Service", "Account", "Enabled", "URL", "Group"]
+    db_channels = Channel.objects.all()
+    for channel in db_channels:
+        table.add_row(
+            [
+                channel.id,
+                channel.service,
+                channel.account,
+                channel.enabled,
+                channel.self_url(),
+                channel.group,
+            ]
+        )
+        mapping[channel.id] = channel
+
+    return table, mapping
+
+
+def show_channel_groups_table() -> tuple[PrettyTable, dict[int, Group]]:
+    """
+    Builds a table to show the list of channel
+
+    Returns:
+        tuple[PrettyTable, dict[int,Group]]: returns the table and a dict with the data as a tuple
+    """
+    table = PrettyTable()
+    mapping = {}
+    table.field_names = ["ID", "Name", "Channels"]
+    db_groups = Group.objects.all()
+    for group in db_groups:
+        table.add_row(
+            [
+                group.id,
+                group.name,
+                ",".join(
+                    [
+                        f"{ch.get_service_display()}: {ch.account}"
+                        for ch in group.channels.all()
+                    ]
+                ),
+            ]
+        )
+        mapping[group.id] = group
+
+    return table, mapping

--- a/bc/core/utils/tests/base.py
+++ b/bc/core/utils/tests/base.py
@@ -1,0 +1,3 @@
+from faker import Faker
+
+faker = Faker()

--- a/bc/subscription/api_views.py
+++ b/bc/subscription/api_views.py
@@ -112,7 +112,7 @@ def handle_recap_fetch_webhook(request: Request) -> Response:
         docket_alert.save(update_fields=["status"])
 
         # schedule tasks to create the new posts(tweet and toot) without thumbnails.
-        enqueue_posts_for_docket_alert(docket_alert.pk)
+        enqueue_posts_for_docket_alert(docket_alert)
     else:
         # schedule task to retrieve the document and create the transaction before posting.
         queue.enqueue(

--- a/bc/subscription/management/commands/lookup.py
+++ b/bc/subscription/management/commands/lookup.py
@@ -1,7 +1,5 @@
 from django.core.management.base import BaseCommand
 
-from bc.channel.selectors import get_enabled_channels
-from bc.core.utils.status.selectors import get_new_case_template
 from bc.subscription.services import create_or_update_subscription_from_docket
 from bc.subscription.tasks import enqueue_posts_for_new_case
 from bc.subscription.utils.courtlistener import (

--- a/bc/subscription/management/commands/lookup.py
+++ b/bc/subscription/management/commands/lookup.py
@@ -1,11 +1,47 @@
 from django.core.management.base import BaseCommand
 
+from bc.channel.models import Channel, Group
+from bc.core.utils.commands import (
+    show_all_channels_table,
+    show_channel_groups_table,
+)
+from bc.subscription.models import Subscription
 from bc.subscription.services import create_or_update_subscription_from_docket
 from bc.subscription.tasks import enqueue_posts_for_new_case
 from bc.subscription.utils.courtlistener import (
     lookup_docket_by_cl_id,
     subscribe_to_docket_alert,
 )
+
+
+def link_channels_to_subscription(
+    ids: list[int],
+    mapping: dict[int, Channel | Group],
+    subscription: Subscription,
+):
+    """
+    Takes the mapping from the command and creates a link between the subscription
+    and the channel.
+
+    Args:
+        ids (list[int]): list of the id from the user's input
+        mapping (dict[int, Channel  |  Group]): Mapping of objects in the table
+        subscription (Subscription): The subscription object.
+
+    Raises:
+        ValueError: if the provided input is not in the mapping variable.
+    """
+    for record_id in ids:
+        record = mapping.get(record_id)
+
+        if record is None:
+            raise ValueError(f"No channel {record_id}")
+
+        if isinstance(record, Group):
+            for channel in record.channels.all():
+                subscription.channel.add(channel)
+        else:
+            subscription.channel.add(record)
 
 
 class Command(BaseCommand):
@@ -20,6 +56,11 @@ class Command(BaseCommand):
             "--add",
             action="store_true",
             help="Save and Subscribe to the case found using the CL API",
+        )
+        parser.add_argument(
+            "--show_groups",
+            action="store_true",
+            help="Shows the list of groups instead of individual channels",
         )
 
     def handle(self, *args, **options):
@@ -40,10 +81,6 @@ class Command(BaseCommand):
 
         if not options["add"]:
             return
-
-        self.stdout.write(
-            self.style.WARNING("We'll try to add this case to the DB.")
-        )
 
         name = result["case_name"]
         custom_name = input(
@@ -66,9 +103,42 @@ class Command(BaseCommand):
         if case_summary:
             result["case_summary"] = case_summary
 
+        instance = "group" if options["show_groups"] else "channel"
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"\nPick one of more {instance}s from the following table to link to this subscription"
+            )
+        )
+
+        if options["show_groups"]:
+            table, mapping = show_channel_groups_table()
+        else:
+            table, mapping = show_all_channels_table()
+
+        self.stdout.write(self.style.SUCCESS(table))
+
+        ch_input = input(
+            f"Which {instance}? Input ID, comma-separate for multiple, "
+            "or 'all' for all of them.\n"
+        )
+
+        if ch_input == "all":
+            input_ids = list(mapping.keys())
+        else:
+            input_ids = list(
+                map(int, [s.strip() for s in ch_input.split(",")])
+            )
+
+        self.stdout.write(
+            self.style.WARNING("We'll try to add this case to the DB.")
+        )
+
         subscription, created = create_or_update_subscription_from_docket(
             result
         )
+
+        link_channels_to_subscription(input_ids, mapping, subscription)
+
         message = "Added!" if created else "Updated!"
         self.stdout.write(self.style.SUCCESS(message))
 

--- a/bc/subscription/management/commands/subscribe.py
+++ b/bc/subscription/management/commands/subscribe.py
@@ -46,8 +46,8 @@ def link_channels_to_subscription(
 
 class Command(BaseCommand):
     help = (
-        "Lookup a case in the RECAP archive by its CourtListener ID, "
-        "optionally add it."
+        "Lookup a case in the RECAP archive by its CourtListener ID and "
+        "add it to the db."
     )
 
     def add_arguments(self, parser):

--- a/bc/subscription/management/commands/subscribe.py
+++ b/bc/subscription/management/commands/subscribe.py
@@ -53,11 +53,6 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument("cl-id", type=str)
         parser.add_argument(
-            "--add",
-            action="store_true",
-            help="Save and Subscribe to the case found using the CL API",
-        )
-        parser.add_argument(
             "--show_groups",
             action="store_true",
             help="Shows the list of groups instead of individual channels",
@@ -79,12 +74,9 @@ class Command(BaseCommand):
         self.stdout.write(self.style.SUCCESS(f"Court: {court}"))
         self.stdout.write(self.style.SUCCESS(f"Link: {cl_url}"))
 
-        if not options["add"]:
-            return
-
         name = result["case_name"]
         custom_name = input(
-            "Enter a name for this case or press enter to use the default:\n\n"
+            "\nEnter a name for this case or press enter to use the default:\n\n"
             f"Default: {name}\n"
             "name: "
         )

--- a/bc/subscription/management/commands/subscribe.py
+++ b/bc/subscription/management/commands/subscribe.py
@@ -53,9 +53,9 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument("cl-id", type=str)
         parser.add_argument(
-            "--show_groups",
+            "--show_channels",
             action="store_true",
-            help="Shows the list of groups instead of individual channels",
+            help="Shows the list of individual channels",
         )
 
     def handle(self, *args, **options):
@@ -95,17 +95,17 @@ class Command(BaseCommand):
         if case_summary:
             result["case_summary"] = case_summary
 
-        instance = "group" if options["show_groups"] else "channel"
+        instance = "channel" if options["show_channels"] else "group"
         self.stdout.write(
             self.style.SUCCESS(
                 f"\nPick one of more {instance}s from the following table to link to this subscription"
             )
         )
 
-        if options["show_groups"]:
-            table, mapping = show_channel_groups_table()
-        else:
+        if options["show_channels"]:
             table, mapping = show_all_channels_table()
+        else:
+            table, mapping = show_channel_groups_table()
 
         self.stdout.write(self.style.SUCCESS(table))
 

--- a/bc/subscription/selectors.py
+++ b/bc/subscription/selectors.py
@@ -1,4 +1,4 @@
-from collections.abc import Iterable
+from django.db.models import QuerySet
 
 from .models import Subscription
 
@@ -7,7 +7,13 @@ def get_subscription_by_case_id(case_id) -> Subscription | None:
     return Subscription.objects.filter(pacer_case_id=case_id).first()
 
 
-def get_subscriptions_for_big_cases() -> Iterable[Subscription]:
+def get_subscriptions_for_big_cases() -> QuerySet[Subscription]:
+    """
+    Returns the list of subscriptions for the Big Cases bot.
+
+    Returns:
+        QuerySet[Subscription]: list of subscriptions
+    """
     return (
         Subscription.objects.filter(channel__group__is_big_cases=True)
         .distinct("cl_docket_id")

--- a/bc/subscription/selectors.py
+++ b/bc/subscription/selectors.py
@@ -1,7 +1,15 @@
-from typing import Optional
+from collections.abc import Iterable
 
 from .models import Subscription
 
 
 def get_subscription_by_case_id(case_id) -> Subscription | None:
     return Subscription.objects.filter(pacer_case_id=case_id).first()
+
+
+def get_subscriptions_for_big_cases() -> Iterable[Subscription]:
+    return (
+        Subscription.objects.filter(channel__group__is_big_cases=True)
+        .distinct("cl_docket_id")
+        .all()
+    )

--- a/bc/subscription/templates/add-case.html
+++ b/bc/subscription/templates/add-case.html
@@ -9,6 +9,7 @@
     <script src="{% static "js/htmx.min.js" %}"></script>
   {% endif %}
   <script src="{% static "js/loading-states.js" %}"></script>
+  <script src="{% static "js/checkbox-group.js" %}"></script>
 {% endblock %}
 
 {% block title %}Add a new case{% endblock %}

--- a/bc/subscription/templates/includes/search_htmx/case-form.html
+++ b/bc/subscription/templates/includes/search_htmx/case-form.html
@@ -28,6 +28,37 @@
       <small id="caseSummaryHelp" class="form-text text-gray-500">A few words to describe the case in social media.</small>
     </div>
 
+    <div class="flex flex-col">
+      <div class="my-2">
+        <label for="channeList">Channels:</label>
+        <span class="text-red-500">*</span>
+      </div>
+      {% for group in channels %}
+        <div class="flex flex-col text-base">
+          <div class="py-2 bg-gray-50">
+            <label for="id_group_{{group.pk}}" class="flex items-center mx-2">
+              <input type="checkbox" name="groups" value="{{group.pk}}" id="id_group_{{group.pk}}" checked data-cg-target="group-{{group.pk}}">
+              <div class="flex ml-2 font-medium">
+                {{ group.name }}
+              </div>
+            </label>
+          </div>
+          <div class="my-2 grid grid-cols-4 gap-4 mx-2">
+            {% for channel in group.channels.all %}
+              <div>
+                <label for="id_channel_{{channel.pk}}" class="flex items-center">
+                  <input type="checkbox" name="channels" value="{{channel.pk}}" id="id_channel_{{channel.pk}}" checked class="group-{{group.pk}}">
+                  <div class="flex ml-2 font-light">
+                    {{channel.get_service_display}}
+                  </div>
+                </label>
+              </div>
+            {% endfor %}
+          </div>
+        </div>
+      {% endfor %}
+    </div>
+
     <div class="flex">
       <div>
         {% include 'includes/submit-button.html' with value='Follow this case' %}
@@ -36,7 +67,6 @@
         {% include 'includes/inlines/spinning-circle.svg'%}
       </div>
     </div>
-
   </div>
 
 </form>

--- a/bc/subscription/templates/includes/search_htmx/case-form.html
+++ b/bc/subscription/templates/includes/search_htmx/case-form.html
@@ -35,20 +35,21 @@
       </div>
       {% for group in channels %}
         <div class="flex flex-col text-base">
-          <div class="py-2 bg-gray-50">
-            <label for="id_group_{{group.pk}}" class="flex items-center mx-2">
-              <input type="checkbox" name="groups" value="{{group.pk}}" id="id_group_{{group.pk}}" checked data-cg-target="group-{{group.pk}}">
-              <div class="flex ml-2 font-medium">
-                {{ group.name }}
-              </div>
-            </label>
+          <div class="p-2 bg-gray-50 flex justify-between font-medium">
+            <div>
+              {{ group.name }}
+            </div>
+            <div class="text-sm self-end">
+              <a href="javascript:void(0)" class="underline text-blue-600 hover:text-blue-800" data-cg-target="group-{{group.pk}}" data-cg-uncheck="check-none-group-{{group.pk}}">All</a> /
+              <a href="javascript:void(0)" class="underline text-blue-600 hover:text-blue-800" id="check-none-group-{{group.pk}}">None</a>
+            </div>
           </div>
           <div class="my-2 grid grid-cols-4 gap-4 mx-2">
             {% for channel in group.channels.all %}
               <div>
                 <label for="id_channel_{{channel.pk}}" class="flex items-center">
                   <input type="checkbox" name="channels" value="{{channel.pk}}" id="id_channel_{{channel.pk}}" checked class="group-{{group.pk}}">
-                  <div class="flex ml-2 font-light">
+                  <div class="flex ml-2 font-normal">
                     {{channel.get_service_display}}
                   </div>
                 </label>

--- a/bc/subscription/templates/includes/search_htmx/search-form.html
+++ b/bc/subscription/templates/includes/search_htmx/search-form.html
@@ -6,7 +6,7 @@
         <div class="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none text-gray-500">
           {% include 'includes/inlines/magnifying-glass.svg'%}
         </div>
-        <input type="text" id="simple-search" name="q"
+        <input type="text" id="simple-search" name="q" autocomplete=off
           class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full pl-10 p-2.5 placeholder-gray-400"
           placeholder="i.e. https://www.courtlistener.com/docket/4214664/national-veterans-legal-services-program-v-united-states/" required>
       </div>

--- a/bc/subscription/tests/factories.py
+++ b/bc/subscription/tests/factories.py
@@ -1,0 +1,21 @@
+import factory
+from factory.django import DjangoModelFactory
+
+from bc.core.utils.tests.base import faker
+from bc.subscription.models import Subscription
+
+
+class SubscriptionFactory(DjangoModelFactory):
+    class Meta:
+        model = Subscription
+
+    cl_docket_id = factory.LazyAttribute(
+        lambda _: faker.random_int(100_000, 400_000)
+    )
+
+    @factory.post_generation
+    def channels(self, create, extracted, **kwargs):
+        if not create or not extracted:
+            return
+
+        self.channel.add(*extracted)

--- a/bc/subscription/tests/test_selectors.py
+++ b/bc/subscription/tests/test_selectors.py
@@ -1,0 +1,20 @@
+from django.test import TestCase
+
+from bc.channel.tests.factories import ChannelFactory, GroupFactory
+from bc.subscription.selectors import get_subscriptions_for_big_cases
+
+from .factories import SubscriptionFactory
+
+
+class GetSubscriptionsForBigCasesTests(TestCase):
+    @classmethod
+    def setUpTestData(cls) -> None:
+        group = GroupFactory(is_big_cases=True)
+        big_cases_channel = ChannelFactory(group=group)
+
+        SubscriptionFactory.create_batch(3)
+        SubscriptionFactory.create_batch(2, channels=[big_cases_channel])
+
+    def test_can_list_big_cases_subscriptions(self):
+        big_cases_subscriptions = get_subscriptions_for_big_cases()
+        self.assertEqual(big_cases_subscriptions.count(), 2)

--- a/bc/subscription/tests/test_utils.py
+++ b/bc/subscription/tests/test_utils.py
@@ -1,7 +1,7 @@
 from django.core.exceptions import ValidationError
 from django.test import SimpleTestCase
 
-from .utils.courtlistener import get_docket_id_from_query
+from bc.subscription.utils.courtlistener import get_docket_id_from_query
 
 
 class SearchBarTest(SimpleTestCase):

--- a/bc/subscription/views.py
+++ b/bc/subscription/views.py
@@ -69,7 +69,7 @@ class AddCaseView(LoginRequiredMixin, View):
         subscription, created = create_or_update_subscription_from_docket(
             docket
         )
-        channels = request.POST.get("channels")
+        channels = request.POST.getlist("channels")
 
         for channel_id in channels:
             subscription.channel.add(channel_id)

--- a/bc/subscription/views.py
+++ b/bc/subscription/views.py
@@ -2,6 +2,7 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 from django.core.exceptions import ValidationError
 from django.shortcuts import render
 from django.views import View
+from django_htmx.http import trigger_client_event
 from requests.exceptions import HTTPError
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -28,6 +29,12 @@ def search(request: Request) -> Response:
             context["case_name"] = data["case_name"]
             context["channels"] = get_channel_groups_per_user(request.user.pk)
             template = "./includes/search_htmx/case-form.html"
+            response = render(request, template, context)
+            return trigger_client_event(
+                response,
+                "groupCheckbox",
+                after="settle",
+            )
     except HTTPError:
         template = "./includes/search_htmx/no-result.html"
     except ValidationError:

--- a/bc/users/tests/factories.py
+++ b/bc/users/tests/factories.py
@@ -1,0 +1,28 @@
+import factory
+from django.contrib.auth.hashers import make_password
+from factory import LazyAttribute, LazyFunction
+from factory.django import DjangoModelFactory
+
+from bc.core.utils.tests.base import faker
+from bc.users.models import User
+
+
+class UserFactory(DjangoModelFactory):
+    class Meta:
+        model = User
+
+    username = LazyAttribute(lambda _: faker.user_name())
+    first_name = LazyAttribute(lambda _: faker.first_name())
+    last_name = LazyAttribute(lambda _: faker.last_name())
+    email = LazyAttribute(lambda _: faker.email())
+    password = LazyFunction(lambda: make_password("password"))
+    is_staff = False
+    is_superuser = False
+    is_active = True
+
+    @factory.post_generation
+    def channels(self, create, extracted, **kwargs):
+        if not create or not extracted:
+            return
+
+        self.channels.add(*extracted)

--- a/bc/web/views.py
+++ b/bc/web/views.py
@@ -9,6 +9,7 @@ from bc.sponsorship.selectors import (
     get_past_sponsor_organization,
 )
 from bc.subscription.models import Subscription
+from bc.subscription.selectors import get_subscriptions_for_big_cases
 
 from .forms import BotSuggestionForm, WaitListForm
 
@@ -51,7 +52,7 @@ def big_cases_about(request: HttpRequest) -> HttpResponse:
         request,
         "big-cases/about.html",
         {
-            "subscriptions": Subscription.objects.all(),
+            "subscriptions": get_subscriptions_for_big_cases(),
         },
     )
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -814,6 +814,40 @@ files = [
 tests = ["asttokens", "littleutils", "pytest", "rich"]
 
 [[package]]
+name = "factory-boy"
+version = "3.2.1"
+description = "A versatile test fixtures replacement based on thoughtbot's factory_bot for Ruby."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "factory_boy-3.2.1-py2.py3-none-any.whl", hash = "sha256:eb02a7dd1b577ef606b75a253b9818e6f9eaf996d94449c9d5ebb124f90dc795"},
+    {file = "factory_boy-3.2.1.tar.gz", hash = "sha256:a98d277b0c047c75eb6e4ab8508a7f81fb03d2cb21986f627913546ef7a2a55e"},
+]
+
+[package.dependencies]
+Faker = ">=0.7.0"
+
+[package.extras]
+dev = ["Django", "Pillow", "SQLAlchemy", "coverage", "flake8", "isort", "mongoengine", "tox", "wheel (>=0.32.0)", "zest.releaser[recommended]"]
+doc = ["Sphinx", "sphinx-rtd-theme", "sphinxcontrib-spelling"]
+
+[[package]]
+name = "faker"
+version = "18.7.0"
+description = "Faker is a Python package that generates fake data for you."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "Faker-18.7.0-py3-none-any.whl", hash = "sha256:38dbc3b80e655d7301e190426ab30f04b6b7f6ca4764c5dd02772ffde0fa6dcd"},
+    {file = "Faker-18.7.0.tar.gz", hash = "sha256:f02c6d3fdb5bc781f80b440cf2bdec336ed47ecfb8d620b20c3d4188ed051831"},
+]
+
+[package.dependencies]
+python-dateutil = ">=2.4"
+
+[[package]]
 name = "filelock"
 version = "3.9.0"
 description = "A platform independent file lock."
@@ -2226,4 +2260,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "c4f6962b08055067cb4f6f2fa9c95dafae1d362e036b80cf8aaa203cf1ab46b1"
+content-hash = "fde421291df376f07407f9fa734e222b2df1d5bf49fc5b1c7cc86298698896bd"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,8 @@ django-ratelimit = "^4.0.0"
 twitterapi = "^2.8.2"
 django-ses = "^3.4.1"
 django-htmx = "^1.14.0"
+factory-boy = "^3.2.1"
+faker = "^18.7.0"
 
 [tool.poetry.group.dev.dependencies]
 black = "^23.1.0"


### PR DESCRIPTION
This PR tweaks queries related to subscription and channels to use the relationships added in #235 and also update the page about the Big Cases Bot and the form to follow new cases.

This PR introduces the following changes:

- Adds a selector called `get_subscriptions_for_big_casesto` to filter the list of subscriptions and show only those linked to channels related to the Big Cases bot and not for the other new bots.

- Add helpers to show the list of channels as a table in the `post` and the `lookup` command

- Refactor the `post` command.

- Tweaks the `lookup` command to show a list of channels and add them to the new subscriptions. 

- Add a new selector function to get channels linked to a user

- Updates the form to add channels from the website to show the list of channels using checkboxes

- Adds a new JS asset to add interaction to the checkboxes in the new form

- Updates the search view to send an HTMX trigger event

- Tweak views in the subscription module to handle the new form to add cases. 

- Add factories for the channel, groups, subscriptions, and user model.

- Add tests for selectors in the subscription and channel module

Here's a gif of the new form to add cases:

![add-case-form-new](https://github.com/freelawproject/bigcases2/assets/55959657/0068bc01-45f7-4ff1-92ba-a270424f4def)

