### PR TITLE
feat(subscription): Tweak the links to the CL dockets

### DIFF
--- a/bc/subscription/models.py
+++ b/bc/subscription/models.py
@@ -81,7 +81,7 @@ class Subscription(AbstractDateTimeModel):
 
     @property
     def cl_url(self) -> str:
-        return f"https://www.courtlistener.com/recap/gov.uscourts.{self.cl_court_id}.{self.pacer_case_id}"
+        return f"https://www.courtlistener.com/docket/{self.cl_docket_id}/{self.cl_slug}/?order_by=desc"
 
     def pacer_district_url(self, path) -> str | None:
         if not self.pacer_case_id or self.cl_court_id in APPELLATE_COURT_IDS:


### PR DESCRIPTION
This PR adds the `order_by` query parameter to the docket links and fixes #252.

This PR updates the property called `cl_url` in the `Subscription` model. The current implementation of this property computes links that redirect the users to the **docket page** in CL but We can't add query parameters to this URL because **Django** removes it while redirecting the request, so We're tweaking the property to return the direct link to the docket page and also adding the order_by parameter.