### PR TITLE
feat(subscription): Adds a human-friendly message for timeout exceptions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,12 +25,16 @@ jobs:
           virtualenvs-create: true
           virtualenvs-in-project: true
 
+      - name: Get full Python version
+        id: full-python-version
+        run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
+
       - name: Load cached venv
         id: cached-poetry-dependencies
         uses: actions/cache@v2
         with:
           path: .venv
-          key: venv-${{ runner.os }}-cache-${{ steps.cp311.outputs.version }}-${{ hashFiles('**/poetry.lock')}}-v20210414
+          key: venv-${{ runner.os }}-cache-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('**/poetry.lock')}}-v20210414
 
       - name: Install dependencies
         run: poetry install

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,12 +38,16 @@ jobs:
           virtualenvs-create: true
           virtualenvs-in-project: true
 
+      - name: Get full Python version
+        id: full-python-version
+        run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
+
       - name: Load cached venv
         id: cached-poetry-dependencies
         uses: actions/cache@v3
         with:
           path: .venv
-          key: venv-${{ runner.os }}-cache-${{ steps.cp311.outputs.version }}-${{ hashFiles('**/poetry.lock')}}-v20210414
+          key: venv-${{ runner.os }}-cache-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('**/poetry.lock')}}-v20210414
 
       - name: Install dependencies
         run: poetry install

--- a/bc/subscription/templates/includes/search_htmx/time-out.html
+++ b/bc/subscription/templates/includes/search_htmx/time-out.html
@@ -1,0 +1,8 @@
+<div class="flex items-center self-center">
+  <div class="flex justify-center items-center self-center h-24 w-24 text-saffron-400">
+    {% include 'includes/inlines/exclamation-triangle.svg' %}
+  </div>
+  <div class="ml-4 text-base">
+    Looks like the server is taking to long to respond, this can be caused by either poor connectivity or an error with our servers. Please try again.
+  </div>
+</div>

--- a/bc/subscription/views.py
+++ b/bc/subscription/views.py
@@ -3,7 +3,7 @@ from django.core.exceptions import ValidationError
 from django.shortcuts import render
 from django.views import View
 from django_htmx.http import trigger_client_event
-from requests.exceptions import HTTPError
+from requests.exceptions import HTTPError, ReadTimeout
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -39,6 +39,8 @@ def search(request: Request) -> Response:
         template = "./includes/search_htmx/no-result.html"
     except ValidationError:
         template = "./includes/search_htmx/invalid-keyword.html"
+    except ReadTimeout:
+        template = "./includes/search_htmx/time-out.html"
 
     return render(request, template, context)
 


### PR DESCRIPTION
This PR adds a template to display a human-friendly message for timeout exceptions and fixes #242. 

Here's a screenshot of the new message:

<img width="1209" alt="Screenshot 2023-06-16 at 3 11 00 PM" src="https://github.com/freelawproject/bigcases2/assets/55959657/127fdd47-ffeb-4252-a941-f1b0dac7b20a">

This PR also adds a new step to the **linting** and **testing** action to create better keys to uniquely identify each version of our cache.

