### PR TITLE
chore(dockerfile): Update node version in docker images

### DIFF
--- a/docker/django/Dockerfile
+++ b/docker/django/Dockerfile
@@ -4,7 +4,7 @@ FROM python:3.11-slim as build-base
 
 RUN apt-get update --option "Acquire::Retries=3" --quiet=2 && \
     apt-get install -y build-essential curl &&\
-    curl -sL https://deb.nodesource.com/setup_14.x | bash - && \
+    curl -sL https://deb.nodesource.com/setup_20.x | bash - && \
     apt-get install \
         --no-install-recommends \
         --assume-yes \


### PR DESCRIPTION
After merging #265, I realized the [Build and deploy](https://github.com/freelawproject/bigcases2/actions/runs/5292810658/jobs/9580217372)  step failed and showed the following error:

```
It looks like node.js and/or npm is not installed or cannot be found.

Visit https://nodejs.org/ to download and install node.js for your system.

If you have npm installed and still getting this error message, set the NPM_BIN_PATH variable in settings.py to 
match path of NPM executable in your system.

```

I tried setting the `NPM_BIN_PATH` variable but it didn't work. I found that using a newer version of Nodejs fixes the issue, so this PR updates the version installed from nodesource to fix this bug.