### PR TITLE
fix(security): adjust CSP policy to accomodate Tailwindcss

### DIFF
--- a/bc/settings/project/security.py
+++ b/bc/settings/project/security.py
@@ -20,6 +20,12 @@ SECURE_CONTENT_TYPE_NOSNIFF = True
 X_FRAME_OPTIONS = "DENY"
 SECURE_REFERRER_POLICY = "same-origin"
 CSP_CONNECT_SRC = ("'self'", "https://plausible.io/")
+CSP_IMG_SRC = (
+    "'self'",
+    AWS_S3_CUSTOM_DOMAIN,
+    "https://plausible.io/",
+    "data:",  # @tailwindcss/forms uses data URIs for images.
+)
 CSP_SCRIPT_SRC = (
     "'self'",
     AWS_S3_CUSTOM_DOMAIN,


### PR DESCRIPTION
The `@tailwindcss/forms` plugin, uses data URIs for form elements in CSS. Allow these by adding `data:` to the allowed image sources of the content security policy.

Fixes: #297