### PR TITLE
fix(web): z-ordering of dropdown

### DIFF
--- a/bc/assets/templates/includes/header.html
+++ b/bc/assets/templates/includes/header.html
@@ -15,9 +15,9 @@
                       {% include './inlines/bars.svg' %}
                     </div>
                 </button>
-                <div class="absolute w-full pl-8 sm:pl-12">
+                <div class="absolute z-10 w-full pl-8 sm:pl-12">
 
-                  <div id="dropdown-mobile" class="z-10 bg-white hidden divide-y divide-gray-100 rounded-lg shadow-lg ring-1 ring-black ring-opacity-5 overflow-hidden w-full">
+                  <div id="dropdown-mobile" class="bg-white hidden divide-y divide-gray-100 rounded-lg shadow-lg ring-1 ring-black ring-opacity-5 overflow-hidden w-full">
                     <div class="pt-5 pb-6 px-5">
                       <div class="flex items-start justify-between">
                         <img alt='Yellow robot with white background logo' src="{% static "svg/icon.svg" %}"  layout="responsive" class="rounded-lg h-16 w-16 bg-white"/>


### PR DESCRIPTION
`z-index` determines ordering relative to an element's closest `relative` ancestor. The z-order of the dropdown is relative to z-order of its `absolute`-ly positioned parent.

This parent and the container of the input share a `relative` container (`<body>`) and, having no explicit index, are ordered by lexically. The input container comes later, and so it is ordered above the dropdown container. A child element cannot transcend its parent's z-order, and so the input rendered above the container. Fix by placing the `z-index` on the `absolute` container.

Fixes: #314