### PR TITLE
feat(security): add `report-sample` to script-src of CSP

### DIFF
--- a/bc/settings/project/security.py
+++ b/bc/settings/project/security.py
@@ -28,12 +28,14 @@ CSP_IMG_SRC = (
 )
 CSP_SCRIPT_SRC = (
     "'self'",
+    "'report-sample'",
     AWS_S3_CUSTOM_DOMAIN,
     "https://plausible.io/",
     "https://hcaptcha.com/",
 )
 CSP_DEFAULT_SRC = (
     "'self'",
+    "'report-sample'",
     AWS_S3_CUSTOM_DOMAIN,
     "https://newassets.hcaptcha.com/",
 )


### PR DESCRIPTION
This keyword leads the browser to add a `sample` entry to violation reports (for `style` and `script`) and is useful for distinguishing otherwise identical reports. It is also helpful for diagnosis.

The sample is 40 characters of context for the source code that triggered the violation. It does not contain content (read: PII) (https://www.w3.org/TR/CSP3/#violation-sample).