### PR TITLE
chore(docker): drop ports from ancillary containers

### DIFF
--- a/docker/bigcasesbot/docker-compose.yml
+++ b/docker/bigcasesbot/docker-compose.yml
@@ -18,8 +18,6 @@ services:
 
   bc2-postgresql:
     container_name: bc2-postgresql
-    ports:
-      - "5433:5432"
     image: postgres:15.2-alpine
     environment:
       POSTGRES_USER: "postgres"
@@ -31,8 +29,6 @@ services:
   bc2-redis:
     container_name: bc2-redis
     image: redis:7-alpine
-    ports:
-      - "6379:6379"
     networks:
       - bc2_net_overlay
 


### PR DESCRIPTION
`bc2-redis`'s use of `6379` conflicts with `cl-redis` (CourtListener) and frustrates parallel development. There's no need for the `bc2-redis` and `bc2-postgresql` container ports to be exposed on the host. It is enough that they are accessible within the `bc2_net_overlay` Docker network.