### PR TITLE
fix(subscription): Create alert in CourtListener after adding a case

### DIFF
--- a/bc/subscription/views.py
+++ b/bc/subscription/views.py
@@ -18,6 +18,7 @@ from .tasks import check_initial_complaint_before_posting
 from .utils.courtlistener import (
     get_docket_id_from_query,
     lookup_docket_by_cl_id,
+    subscribe_to_docket_alert,
 )
 
 queue = get_queue("default")
@@ -96,5 +97,14 @@ class AddCaseView(LoginRequiredMixin, View):
                     interval=settings.RQ_RETRY_INTERVAL,
                 ),
             )
+
+        queue.enqueue(
+            subscribe_to_docket_alert,
+            docket["id"],
+            retry=Retry(
+                max=settings.RQ_MAX_NUMBER_OF_RETRIES,
+                interval=settings.RQ_RETRY_INTERVAL,
+            ),
+        )
 
         return render(request, "./includes/search_htmx/success.html")


### PR DESCRIPTION
After checking the issue reported in Slack about **J6 cases**, I noticed the **Bot** didn't create an alert for the case in CL. As a result, the bot didn't get the webhooks about its new entries. 

This PR fixes this bug by adding logic to enqueue a job that creates the alerts in CL after users submit the follow-a-case form. 

I already checked all the existing subscriptions and fixed those that didn't create the alert. 