### PR TITLE
feature(security): drop Content Security Policy violation reporting

### DIFF
--- a/bc/settings/project/security.py
+++ b/bc/settings/project/security.py
@@ -70,8 +70,6 @@ if not any(
     (DEVELOPMENT, TESTING)
 ):  # Development and test aren’t used over HTTPS (yet)
     CSP_UPGRADE_INSECURE_REQUESTS = True
-if SENTRY_REPORT_URI:
-    CSP_REPORT_URI = SENTRY_REPORT_URI
 
 
 RATELIMIT_VIEW = "bc.web.views.ratelimited"


### PR DESCRIPTION
Since CSP release, we've reached the point where all remaining violations are not caused by Bots.law, but rather by idiosyncratic (and mostly undesirable) browser behavior (largely extensions).

Unfortunately, the volume of these remaining reports is too high; the burden of review is unsustainable. Sacrifice this visibilty and, instead, rely on the regular QA patterns we depend on for other front-end issues (e.g. Javascript exceptions, broken markup).

Fixes: #350