### PR TITLE
fix(sponsorship): Tweak logic to filter sponsored groups

### DIFF
--- a/bc/channel/selectors.py
+++ b/bc/channel/selectors.py
@@ -55,7 +55,7 @@ def get_sponsored_groups_per_subscription(
     subscription_pk: int,
 ) -> QuerySet[Group]:
     """
-    Returns the set of channel groups that has an active sponsorship and
+    Returns the set of channel groups that has been sponsored and
     are related to the given subscription.
 
     Args:
@@ -70,7 +70,7 @@ def get_sponsored_groups_per_subscription(
             sponsorships__isnull=False,
         )
         .prefetch_related(
-            Prefetch(  # retrieve only Groups related to the subscription
+            Prefetch(  # retrieve only active sponsorships
                 "sponsorships",
                 queryset=Sponsorship.objects.filter(
                     current_amount__gte=3.00

--- a/bc/sponsorship/services.py
+++ b/bc/sponsorship/services.py
@@ -19,12 +19,13 @@ def log_purchase(
     webhook event and the subscription record.
 
     Args:
-        sponsored_groups (Sponsorship): Set of channels groups with available sponsorships.
+        sponsored_groups (Sponsorship): Set of sponsored channels groups following the case.
         subscription_pk (int): PK of the subscription record related to the document.
         document (Document): Document instance that stores data of the file that was bought.
     """
+    # Gets the ids of the active sponsorships from each sponsor group.
     sponsorship_ids: list[int] = [
-        group.sponsorships.first().pk for group in sponsored_groups if group.sponsorships  # type: ignore
+        group.sponsorships.first().pk for group in sponsored_groups if group.sponsorships.count()  # type: ignore
     ]
     sponsorships = get_sponsorships_for_subscription(
         sponsorship_ids, subscription_pk

--- a/bc/sponsorship/tests/test_services.py
+++ b/bc/sponsorship/tests/test_services.py
@@ -16,17 +16,20 @@ from .factories import SponsorshipFactory
 class LogPurchaseTest(TestCase):
     subscription = None
     webhook_event = None
+    act_sponsorship_2 = None
+    act_sponsorship_3 = None
+    document = None
 
     @classmethod
     def setUpTestData(cls) -> None:
         act_sponsorship_1 = SponsorshipFactory.create_batch(2)
-        act_sponsorship_2 = SponsorshipFactory()
-        act_sponsorship_3 = SponsorshipFactory()
+        cls.act_sponsorship_2 = SponsorshipFactory()
+        cls.act_sponsorship_3 = SponsorshipFactory()
 
         group_1 = GroupFactory(sponsorships=act_sponsorship_1)
-        group_2 = GroupFactory(sponsorships=[act_sponsorship_2])
+        group_2 = GroupFactory(sponsorships=[cls.act_sponsorship_2])
         group_3 = GroupFactory(
-            sponsorships=[act_sponsorship_2, act_sponsorship_3]
+            sponsorships=[cls.act_sponsorship_2, cls.act_sponsorship_3]
         )
         group_4 = GroupFactory()
 
@@ -43,22 +46,46 @@ class LogPurchaseTest(TestCase):
             docket_id=cls.subscription.cl_docket_id,
         )
 
+        cls.document = Document(
+            description=str(cls.webhook_event),
+            docket_number=cls.webhook_event.subscription.docket_number,
+            court_name=cls.webhook_event.subscription.court_name,
+            court_id=cls.webhook_event.subscription.pacer_court_id,
+            page_count=10,
+        )
+
     def test_can_split_transactions(self):
         sponsored_groups = get_sponsored_groups_per_subscription(
             self.subscription.pk
         )
-        document = Document(
-            description=str(self.webhook_event),
-            docket_number=self.webhook_event.subscription.docket_number,
-            court_name=self.webhook_event.subscription.court_name,
-            court_id=self.webhook_event.subscription.pacer_court_id,
-            page_count=10,
-        )
+
         log_purchase(
-            sponsored_groups, self.webhook_event.subscription.id, document
+            sponsored_groups, self.webhook_event.subscription.id, self.document
         )
 
         purchase_transactions = Transaction.objects.filter(
             type=Transaction.DOCUMENT_PURCHASE
         ).all()
         self.assertEqual(purchase_transactions.count(), 2)
+
+    def test_can_log_purchase_after_one_sponsorship_run_out_of_money(self):
+        # We need to disable sponsorship 2 to avoid creating a purchase transaction from group 2
+        self.act_sponsorship_2.current_amount = 0
+        self.act_sponsorship_2.save()
+
+        # We need to disable sponsorship 3 to avoid creating a purchase transaction from group 3
+        self.act_sponsorship_3.current_amount = 0
+        self.act_sponsorship_3.save()
+
+        sponsored_groups = get_sponsored_groups_per_subscription(
+            self.subscription.pk
+        )
+        log_purchase(
+            sponsored_groups, self.webhook_event.subscription.id, self.document
+        )
+
+        purchase_transactions = Transaction.objects.filter(
+            type=Transaction.DOCUMENT_PURCHASE
+        ).all()
+        # We should get just one transaction from group 1
+        self.assertEqual(purchase_transactions.count(), 1)


### PR DESCRIPTION
This PR fixes #369.

In line [27](https://github.com/freelawproject/bigcases2/blob/e5a90abf668beeb21d773c9a73e5c12f0aedb7e9/bc/sponsorship/services.py#L27), the code raised an exception and it appears that the list comprehension was unable to obtain the sponsorship PK.

In #369, the transaction we tried to log is related to a document that belongs to a case followed by two sponsored group( big cases and tech cases) but the sponsorship from big cases is not available (we spent all that money :( ). The code should've skipped the big cases group but it tried to get the active sponsorship of that group and that raised the exception. 

I thought that was odd because we're using a filter(`if group.sponsorships`) to check whether the group has a sponsorship or not before trying to get the `pk` and thats when I realized the `.sponsorships` attribute returns a `ManyRelatedManager` object so the `if statement` is always True( the filter is not working 💀 ). I added the .count() method so the if statement will only accepts the items with active sponsorship.

I also added a test for this case. 