### PR TITLE
fix(build): use manual installation for python Poetry 

### DIFF
--- a/docker/django/Dockerfile
+++ b/docker/django/Dockerfile
@@ -28,15 +28,13 @@ ENV POETRY_VERSION=1.3.2 \
     # do not ask any interactive question
     POETRY_NO_INTERACTION=1
 
-# install poetry - respects $POETRY_VERSION & $POETRY_HOME
-RUN curl -sSL https://install.python-poetry.org | python3 -
-
 ENV PYTHONUNBUFFERED=1 \
-    # this is where our requirements will be loaded
+    # this is where our requirements are copied to
     PYSETUP_PATH="/opt/pysetup"
 
-# prepend poetry and venv to path
-ENV PATH="/opt/poetry/bin:$PATH"
+RUN python -m venv $POETRY_HOME && \
+    $POETRY_HOME/bin/pip install poetry==$POETRY_VERSION --quiet --upgrade && \
+    ln -s $POETRY_HOME/bin/poetry "$(dirname $(which python))/poetry"  # make accessible via $PATH
 
 
 FROM build-base as build-dev

--- a/docker/django/Dockerfile
+++ b/docker/django/Dockerfile
@@ -31,8 +31,6 @@ ENV POETRY_VERSION=1.3.2 \
 # install poetry - respects $POETRY_VERSION & $POETRY_HOME
 RUN curl -sSL https://install.python-poetry.org | python3 -
 
-ARG POETRY_HOME
-
 ENV PYTHONUNBUFFERED=1 \
     # paths
     # where to create the env

--- a/docker/django/Dockerfile
+++ b/docker/django/Dockerfile
@@ -32,14 +32,11 @@ ENV POETRY_VERSION=1.3.2 \
 RUN curl -sSL https://install.python-poetry.org | python3 -
 
 ENV PYTHONUNBUFFERED=1 \
-    # paths
-    # where to create the env
-    VENV_PATH="/opt/pysetup/.venv" \
-    # this is where our requirements + virtual environment will live
+    # this is where our requirements will be loaded
     PYSETUP_PATH="/opt/pysetup"
 
 # prepend poetry and venv to path
-ENV PATH="/opt/poetry/bin:$VENV_PATH/bin:$PATH"
+ENV PATH="/opt/poetry/bin:$PATH"
 
 
 FROM build-base as build-dev


### PR DESCRIPTION
_Analogue of freelawproject/courtlistener#3110_

The Docker image, `python:3.11-slim`, that images are built from, recently stopped working with the installation script that is downloaded and executed for the Poetry tool:
```
RUN curl -sSL https://install.python-poetry.org/ | python3 -
```
Instead of this script, use the installation with `pip` that is a alternative approach which doesn't have this problem and is more direct than the script.

Also in this branch:
- Removal of surplus `POETRY_HOME` argument
- Remove nonoperative `VENV_PATH` environment variable
