### PR TITLE
Revert "chore(build): use www-data user for all services"

### DIFF
--- a/docker/django/Dockerfile
+++ b/docker/django/Dockerfile
@@ -82,20 +82,17 @@ WORKDIR /opt/bigcases2
 # freelawproject/bigcases2:latest-rq
 FROM python-base as rq
 
-USER www-data
 CMD python manage.py rqworker --with-scheduler
 
 # freelawproject/bigcases2:latest-tailwind-reload-dev
 FROM python-base as tailwind-reload-dev
 
-USER www-data
 CMD python /opt/bigcases2/manage.py tailwind install --no-input  && \
     python /opt/bigcases2/manage.py tailwind start --no-input
 
 #freelawproject/bigcases2:latest-web-dev
 FROM python-base as web-dev
 
-USER www-data
 CMD python /opt/bigcases2/manage.py migrate  && \
     python /opt/bigcases2/manage.py runserver 0.0.0.0:8000
 
@@ -104,7 +101,6 @@ WORKDIR /opt/bigcases2
 #freelawproject/bigcases2:latest-web-prod
 FROM python-base as web-prod
 
-USER www-data
 CMD python /opt/bigcases2/manage.py migrate && \
     gunicorn wsgi:application \
     --chdir /opt/bigcases2/docker/django/wsgi-configs/ \


### PR DESCRIPTION
Reverts freelawproject/bigcases2#379

`django-tailwind` does not play well with this change. Addressing this will take some extra attention – revert for now.