### PR TITLE
chore(build): drop use of github archive and merge build-* stages

### DIFF
--- a/docker/django/Dockerfile
+++ b/docker/django/Dockerfile
@@ -53,18 +53,13 @@ FROM build-base as build-prod
 WORKDIR $PYSETUP_PATH
 
 # copy project requirement files here to ensure they will be cached.
-ADD https://raw.githubusercontent.com/freelawproject/bigcases2/main/poetry.lock /opt/poetry.lock
-ADD https://raw.githubusercontent.com/freelawproject/bigcases2/main/pyproject.toml /opt/pyproject.toml
+COPY poetry.lock ./
+COPY pyproject.toml ./
 
 # install runtime deps
 RUN poetry install --no-root
 
-
-ADD https://github.com/freelawproject/bigcases2/archive/main.tar.gz /opt/bigcases2.tar.gz
-WORKDIR /opt
-RUN tar xvfz bigcases2.tar.gz && \
-    mv /opt/bigcases2-main /opt/bigcases2 && \
-    rm -r /opt/bigcases2.tar.gz
+COPY . /opt/bigcases2
 
 
 # `python-base` sets up all our shared environment variables

--- a/docker/django/Dockerfile
+++ b/docker/django/Dockerfile
@@ -37,33 +37,15 @@ RUN python -m venv $POETRY_HOME && \
     ln -s $POETRY_HOME/bin/poetry "$(dirname $(which python))/poetry"  # make accessible via $PATH
 
 
-FROM build-base as build-dev
+ARG BUILD_ENV=prod
+FROM build-base as python-base
 
 WORKDIR $PYSETUP_PATH
 
-COPY poetry.lock ./
-COPY pyproject.toml ./
-RUN poetry install
+COPY poetry.lock pyproject.toml ./
+RUN poetry install --no-root $(test "$BUILD_ENV" != "dev" && echo "--without dev")
 
 COPY . /opt/bigcases2
-
-
-FROM build-base as build-prod
-
-WORKDIR $PYSETUP_PATH
-
-# copy project requirement files here to ensure they will be cached.
-COPY poetry.lock ./
-COPY pyproject.toml ./
-
-# install runtime deps
-RUN poetry install --no-root
-
-COPY . /opt/bigcases2
-
-
-# `python-base` sets up all our shared environment variables
-FROM build-${BUILD_ENV} as python-base
 
 WORKDIR /opt
 


### PR DESCRIPTION
_Analogue to freelawproject/courtlistener#3130_

Building production from a downloaded archive rather than the Docker build context was done to guard against the risk that an unclean working copy could cause WIP code to be deployed.

Today, responsibility for building and deployment are entirely handled by CD process (Github Actions). This is the best practice and has made the archive download safeguard unnecessary.

Change the `build-prod` target to use the Docker buildcontext rather than a downloaded copy of the repository. Once done, the only remaining difference between the two targets is the --without dev option. Eliminate this difference by using `$BUILD_ENV` for the `RUN` instruction and merging the, otherwise identical, stages.