### PR TITLE
fix(subscription): Add logic to handle the MultipleObjectsReturned exception

### DIFF
--- a/bc/subscription/admin.py
+++ b/bc/subscription/admin.py
@@ -2,7 +2,7 @@ from django.contrib import admin
 
 from bc.channel.models import Channel
 
-from .models import Subscription
+from .models import FilingWebhookEvent, Subscription
 
 
 class ChannelInline(admin.StackedInline):
@@ -18,3 +18,4 @@ class SubscriptionAdmin(admin.ModelAdmin):
 
 
 admin.site.register(Subscription, SubscriptionAdmin)
+admin.site.register(FilingWebhookEvent)

--- a/bc/subscription/api_views.py
+++ b/bc/subscription/api_views.py
@@ -116,6 +116,11 @@ def handle_recap_fetch_webhook(request: Request) -> Response:
         webhook_record = FilingWebhookEvent.objects.get(
             doc_id=data["payload"]["recap_document"]
         )
+    except FilingWebhookEvent.MultipleObjectsReturned:
+        # we have received the same docket entry in different webhooks
+        webhook_record = FilingWebhookEvent.objects.filter(  # type: ignore
+            doc_id=data["payload"]["recap_document"]
+        ).first()
     except FilingWebhookEvent.DoesNotExist:
         # if we dont have a filing webhook related to the document, It must be an initial complaint
         webhook_record = Subscription.objects.get(


### PR DESCRIPTION
This PR adds logic to handle the `MultipleObjectsReturned` exception and also adds the `FilingWebhookEvent` model to the admin interface so we can remove duplicate entries.

Here's a screenshot of the new list in the admin panel:


<img width="875" alt="Screenshot 2023-10-17 at 6 35 53 PM" src="https://github.com/freelawproject/bigcases2/assets/55959657/7fa03ded-95ea-4366-b1c2-219a2239a654">
