### PR TITLE
feat(utils): Add logic to count emojis according to the Twitter spec

### DIFF
--- a/bc/core/utils/string_utils.py
+++ b/bc/core/utils/string_utils.py
@@ -8,7 +8,11 @@ def trunc(s: str, length: int, ellipsis: str | None = None) -> str:
     addition of the ellipsis without being longer than length.
     """
     if ellipsis:
-        ellipsis_length = len(ellipsis)
+        # Emojis are encoded as multiple characters, so we need to count them
+        # individually.
+        ellipsis_length = sum(
+            [2 if len(char.encode("utf-8")) > 1 else 1 for char in ellipsis]
+        )
     else:
         ellipsis_length = 0
 


### PR DESCRIPTION
This PR refines the helper function that truncates long descriptions for posts. 

While debugging the latest events related to this [sentry issue](https://freelawproject.sentry.io/issues/4088080862). I discovered that the API was throwing an error regarding the post length. Upon revisiting the [Twitter specification for character count](https://developer.twitter.com/en/docs/counting-characters), I realized that the API counts emoji as two characters. However, our current `trunc` method was not accounting for this, leading to potential truncation issues.