### PR TITLE
feat(channels): Refine media upload for Bluesky posts

### DIFF
--- a/bc/channel/utils/connectors/bluesky.py
+++ b/bc/channel/utils/connectors/bluesky.py
@@ -29,16 +29,19 @@ class BlueskyConnector:
         media: list[Thumbnail] = []
         if text_image:
             blob = self.upload_media(text_image.to_bytes(), None)
-            media.append(
-                {
-                    "alt": text_image_alt_text(text_image.description),
-                    "image": blob,
-                }
-            )
+            if blob:
+                media.append(
+                    {
+                        "alt": text_image_alt_text(text_image.description),
+                        "image": blob,
+                    }
+                )
 
         if thumbnails:
             for idx, thumbnail in enumerate(thumbnails):
                 blob = self.upload_media(thumbnail, None)
+                if not blob:
+                    continue
                 media.append(
                     {
                         "alt": thumb_num_alt_text(idx),


### PR DESCRIPTION
This PR tweaks the post_media method to handle big thumbnails by logging the error and returning `None` instead of raising an exception. This new approach allows us to exclude those big thumbnails from the embed array and continue the post-creation process.

Fixes #436 