### PR TITLE
fix(template): Tweak method to check output validity in the base class

### DIFF
--- a/bc/core/tests/test_mastodon_template.py
+++ b/bc/core/tests/test_mastodon_template.py
@@ -2,7 +2,156 @@ from textwrap import wrap
 
 from django.test import SimpleTestCase
 
-from bc.core.utils.status.templates import MastodonTemplate
+from bc.core.utils.status.templates import (
+    BLUESKY_FOLLOW_A_NEW_CASE,
+    BLUESKY_FOLLOW_A_NEW_CASE_W_ARTICLE,
+    MASTODON_FOLLOW_A_NEW_CASE,
+    MASTODON_FOLLOW_A_NEW_CASE_W_ARTICLE,
+    TWITTER_FOLLOW_A_NEW_CASE,
+    TWITTER_FOLLOW_A_NEW_CASE_W_ARTICLE,
+    MastodonTemplate,
+)
+
+
+class NewSubscriptionValidTemplateTest(SimpleTestCase):
+    def setUp(self) -> None:
+        self.docket_url = "https://www.courtlistener.com/docket/68073028/01208579363/united-states-v-donald-trump/?redirect_or_modal=True"
+        self.article_url = "https://www.theverge.com/2023/9/11/23868870/internet-archive-hachette-open-library-copyright-lawsuit-appeal"
+        self.docket_id = "68073028"
+        return super().setUp()
+
+    def test_check_output_validity_mastodon_simple_template(self):
+        template = MASTODON_FOLLOW_A_NEW_CASE
+        valid_multipliers = [5, 10, 20, 40, 48]
+        for multiplier in valid_multipliers:
+            template.format(
+                docket=multiplier * "short",
+                docket_link=self.docket_url,
+                docket_id=self.docket_id,
+                article_url=self.article_url,
+            )
+            self.assertTrue(template.is_valid)
+
+        invalid_multipliers = [50, 100]
+        for multiplier in invalid_multipliers:
+            template.format(
+                docket=multiplier * "short",
+                docket_link=self.docket_url,
+                docket_id=self.docket_id,
+                article_url=self.article_url,
+            )
+            self.assertFalse(template.is_valid)
+
+    def test_check_output_validity_mastodon_template_w_article(self):
+        template = MASTODON_FOLLOW_A_NEW_CASE_W_ARTICLE
+        valid_multipliers = [5, 10, 20, 40]
+        for multiplier in valid_multipliers:
+            template.format(
+                docket=multiplier * "short",
+                docket_link=self.docket_url,
+                docket_id=self.docket_id,
+                article_url=self.article_url,
+            )
+
+            self.assertTrue(template.is_valid)
+
+        invalid_multipliers = [41, 50, 100]
+        for multiplier in invalid_multipliers:
+            template.format(
+                docket=multiplier * "short",
+                docket_link=self.docket_url,
+                docket_id=self.docket_id,
+                article_url=self.article_url,
+            )
+            self.assertFalse(template.is_valid)
+
+    def test_check_output_validity_twitter_simple_template(self):
+        template = TWITTER_FOLLOW_A_NEW_CASE
+        valid_multipliers = [5, 10, 20, 40, 44]
+        for multiplier in valid_multipliers:
+            template.format(
+                docket=multiplier * "short",
+                docket_link=self.docket_url,
+                docket_id=self.docket_id,
+                article_url=self.article_url,
+            )
+            self.assertTrue(template.is_valid)
+
+        invalid_multipliers = [45, 50, 100]
+        for multiplier in invalid_multipliers:
+            template.format(
+                docket=multiplier * "short",
+                docket_link=self.docket_url,
+                docket_id=self.docket_id,
+                article_url=self.article_url,
+            )
+            self.assertFalse(template.is_valid)
+
+    def test_check_output_validity_twitter_template_w_article(self):
+        template = TWITTER_FOLLOW_A_NEW_CASE_W_ARTICLE
+        valid_multipliers = [5, 10, 20, 35]
+        for multiplier in valid_multipliers:
+            template.format(
+                docket=multiplier * "short",
+                docket_link=self.docket_url,
+                docket_id=self.docket_id,
+                article_url=self.article_url,
+            )
+            self.assertTrue(template.is_valid)
+
+        invalid_multipliers = [37, 50, 100]
+        for multiplier in invalid_multipliers:
+            template.format(
+                docket=multiplier * "short",
+                docket_link=self.docket_url,
+                docket_id=self.docket_id,
+                article_url=self.article_url,
+            )
+            self.assertFalse(template.is_valid)
+
+    def test_check_output_validity_bluesky_simple_template(self):
+        template = BLUESKY_FOLLOW_A_NEW_CASE
+        valid_multipliers = [5, 10, 20, 40, 50]
+        for multiplier in valid_multipliers:
+            template.format(
+                docket=multiplier * "short",
+                docket_link=self.docket_url,
+                docket_id=self.docket_id,
+                article_url=self.article_url,
+            )
+            self.assertTrue(template.is_valid)
+
+        invalid_multipliers = [51, 100]
+        for multiplier in invalid_multipliers:
+            template.format(
+                docket=multiplier * "short",
+                docket_link=self.docket_url,
+                docket_id=self.docket_id,
+                article_url=self.article_url,
+            )
+            self.assertFalse(template.is_valid)
+
+    def test_check_output_validity_bluesky_template_w_article(self):
+        template = BLUESKY_FOLLOW_A_NEW_CASE_W_ARTICLE
+        valid_multipliers = [5, 10, 20, 40, 46]
+        for multiplier in valid_multipliers:
+            template.format(
+                docket=multiplier * "short",
+                docket_link=self.docket_url,
+                docket_id=self.docket_id,
+                article_url=self.article_url,
+            )
+            self.assertTrue(template.is_valid)
+
+        invalid_multipliers = [47, 50, 100]
+        for multiplier in invalid_multipliers:
+            template.format(
+                docket=multiplier * "short",
+                docket_link=self.docket_url,
+                docket_id=self.docket_id,
+                article_url=self.article_url,
+            )
+            self.assertFalse(template.is_valid)
 
 
 class MastodonTemplateTest(SimpleTestCase):

--- a/bc/core/utils/status/base.py
+++ b/bc/core/utils/status/base.py
@@ -69,13 +69,20 @@ class BaseTemplate:
         """
         Checks whether the provided text exceeds the maximum allowed length.
 
+        Strips links from the output text since they use a fixed character
+        count.
+
         Args:
             text (str): The text to be evaluated.
 
         Returns:
             bool: True if the text length is within the limit, False otherwise.
         """
-        return len(text) <= self.max_characters
+        url_pattern = r"https?://\S+"
+        url_match = re.findall(url_pattern, text)
+        output = re.sub(url_pattern, "", text)
+
+        return len(output) + 23 * len(url_match) <= self.max_characters
 
     def format(self, *args, **kwargs) -> tuple[str, TextImage | None]:
         image = None


### PR DESCRIPTION
This PR tweaks the implementation of the `_check_output_validity` method in the `BaseTemplate` class. 

The current implementation of the method in the `BaseTemplate` class is using `len` to count the characters in the output but this approach is inaccurate for Mastodon and Twitter templates because adds the full length of the links to the count. This is not an issue for the Bluesky template class because we implemented a custom method. This issue with the character count led to misleading error messages in the `add-a-case` form and prevented users from following new cases.

This PR adds logic to remove links from the output and fixes the character count. Additionally, it adds a test to prevent regressions.