### PR TITLE
feat(bluesky): Updates the Session dataclass

### DIFF
--- a/bc/channel/utils/connectors/bluesky_api/types.py
+++ b/bc/channel/utils/connectors/bluesky_api/types.py
@@ -11,6 +11,7 @@ class Session:
     didDoc: dict
     email: str
     emailConfirmed: bool
+    emailAuthFactor: bool
 
 
 @dataclass


### PR DESCRIPTION
Updates `Session` class to handle 'emailAuthFactor' in the `createSession` response (related to https://github.com/bluesky-social/atproto/pull/2419).