### PR TITLE
feat: Added __repr__ to all connectors + added tests

### DIFF
--- a/bc/channel/tests/test_bluesky_connector.py
+++ b/bc/channel/tests/test_bluesky_connector.py
@@ -1,0 +1,18 @@
+from unittest.mock import patch
+
+from django.test import SimpleTestCase
+
+from bc.channel.tests.factories import fake_token
+from bc.channel.utils.connectors.bluesky import BlueskyConnector
+
+
+class ReprTest(SimpleTestCase):
+    @patch("bc.channel.utils.connectors.bluesky_api.client.BlueskyAPI")
+    @patch.object(BlueskyConnector, "get_api_object")
+    def test_repr(self, _get_api_object, _mock_bluesky_api):
+        identifier = "bigcases.bots.law"
+        bluesky_conn = BlueskyConnector(identifier, fake_token())
+        self.assertEqual(
+            repr(bluesky_conn),
+            f"<bc.channel.utils.connectors.bluesky.BlueskyConnector: identifier:'{identifier}'>",
+        )

--- a/bc/channel/tests/test_models.py
+++ b/bc/channel/tests/test_models.py
@@ -1,0 +1,66 @@
+from django.test import SimpleTestCase
+from numpy import cast
+
+from bc.channel.models import Channel, Post
+
+
+class ModelsUrlTest(SimpleTestCase):
+    def setUp(self) -> None:
+        self.bluesky_channel = Channel(
+            service=Channel.BLUESKY, account="bigcases.bots.law"
+        )
+        self.mastodon_channel = Channel(
+            service=Channel.MASTODON, account="@bigcases@law.builders"
+        )
+        self.twitter_channel = Channel(
+            service=Channel.TWITTER, account="big_cases"
+        )
+
+    def test_self_url(self) -> None:
+        test_cases = [
+            {
+                "channel": self.bluesky_channel,
+                "expected_url": "https://bsky.app/profile/bigcases.bots.law",
+            },
+            {
+                "channel": self.mastodon_channel,
+                "expected_url": "https://law.builders/@bigcases",
+            },
+            {
+                "channel": self.twitter_channel,
+                "expected_url": "https://twitter.com/big_cases",
+            },
+        ]
+
+        for test in test_cases:
+            with self.subTest(test=test):
+                channel = cast(Channel, test["channel"])
+                self_url = channel.self_url()
+                self.assertEqual(self_url, test["expected_url"])
+
+    def test_post_url(self) -> None:
+        test_cases = [
+            {
+                "channel": self.bluesky_channel,
+                "expected_url": "https://bsky.app/profile/bigcases.bots.law/post/12345",
+            },
+            {
+                "channel": self.mastodon_channel,
+                "expected_url": "https://law.builders/@bigcases/12345",
+            },
+            {
+                "channel": self.twitter_channel,
+                "expected_url": "https://twitter.com/big_cases/status/12345",
+            },
+        ]
+
+        for test in test_cases:
+            with self.subTest(test=test):
+                channel = cast(Channel, test["channel"])
+                post = Post(
+                    channel=channel,
+                    object_id="12345",
+                )
+
+                post_url = post.post_url
+                self.assertEqual(post_url, test["expected_url"])

--- a/bc/channel/tests/test_twitter_connector.py
+++ b/bc/channel/tests/test_twitter_connector.py
@@ -5,6 +5,7 @@ from django.test import SimpleTestCase
 from bc.channel.tests.factories import fake_token
 from bc.channel.utils.connectors.twitter import TwitterConnector
 from bc.core.utils.tests.base import faker
+from bc.settings.third_party import twitter
 
 
 class UploadMediaTest(SimpleTestCase):
@@ -16,7 +17,9 @@ class UploadMediaTest(SimpleTestCase):
     ):
         twitter_conn.get_api_object.return_value = mock_twitter_api
 
-        twitter_conn = TwitterConnector(fake_token(), fake_token())
+        twitter_conn = TwitterConnector(
+            fake_token(), fake_token(), fake_token()
+        )
         twitter_conn.upload_media(mock_image, "image alt text")
 
         expected_upload_media_calls = [
@@ -41,7 +44,9 @@ class AddStatusTest(SimpleTestCase):
     def test_no_image_no_thumbs(self, mock_get_api):
         mock_get_api().request().json.return_value = {"data": {"id": "1"}}
 
-        twitter_conn = TwitterConnector(fake_token(), fake_token())
+        twitter_conn = TwitterConnector(
+            fake_token(), fake_token(), fake_token()
+        )
         result = twitter_conn.add_status("this is the message")
         self.assertEqual(result, "1")
         twitter_conn.api_v2.request.assert_called_with(
@@ -59,7 +64,9 @@ class AddStatusTest(SimpleTestCase):
     ):
         twitter_conn.get_api_object.return_value = mock_twitter_api
 
-        twitter_conn = TwitterConnector(fake_token(), fake_token())
+        twitter_conn = TwitterConnector(
+            fake_token(), fake_token(), fake_token()
+        )
         twitter_conn.add_status("this has an image", text_image=mock_image)
 
         twitter_conn.api_v2.request.assert_called_with(
@@ -86,7 +93,9 @@ class AddStatusTest(SimpleTestCase):
         mock_image.description = "the image description"
         mock_image.to_bytes.return_value = "image bytes"
 
-        twitter_conn = TwitterConnector(fake_token(), fake_token())
+        twitter_conn = TwitterConnector(
+            fake_token(), fake_token(), fake_token()
+        )
         twitter_conn.add_status(
             "this has an image",
             text_image=mock_image,
@@ -108,7 +117,9 @@ class AddStatusTest(SimpleTestCase):
         thumb_4 = faker.binary(8)
         twitter_conn.get_api_object.return_value = mock_twitter_api
 
-        twitter_conn = TwitterConnector(fake_token(), fake_token())
+        twitter_conn = TwitterConnector(
+            fake_token(), fake_token(), fake_token()
+        )
         twitter_conn.add_status(
             "this has 4 thumbnails",
             thumbnails=[thumb_1, thumb_2, thumb_3, thumb_4],
@@ -137,7 +148,9 @@ class AddStatusTest(SimpleTestCase):
             call(thumb_2, "Thumbnail of page 2 of the PDF linked above."),
         ]
 
-        twitter_conn = TwitterConnector(fake_token(), fake_token())
+        twitter_conn = TwitterConnector(
+            fake_token(), fake_token(), fake_token()
+        )
         twitter_conn.add_status(
             "this has 2 thumbnails",
             None,
@@ -155,11 +168,25 @@ class AddStatusTest(SimpleTestCase):
     def test_always_calls_api_v2_request(self, twitter_conn, mock_twitter_api):
         twitter_conn.get_api_object.return_value = mock_twitter_api
 
-        twitter_conn = TwitterConnector(fake_token(), fake_token())
+        twitter_conn = TwitterConnector(
+            fake_token(), fake_token(), fake_token()
+        )
         twitter_conn.add_status("this is the message")
 
         twitter_conn.api_v2.request.assert_called_with(
             "tweets",
             params={"text": "this is the message"},
             method_override="POST",
+        )
+
+
+class ReprTest(SimpleTestCase):
+    @patch("TwitterAPI.TwitterAPI.TwitterAPI")
+    @patch.object(TwitterConnector, "get_api_object")
+    def test_repr(self, _get_api_object, _mock_twitter_api):
+        account = "big_cases"
+        twitter_conn = TwitterConnector(fake_token(), fake_token(), account)
+        self.assertEqual(
+            repr(twitter_conn),
+            f"<bc.channel.utils.connectors.twitter.TwitterConnector: account:'{account}'>",
         )

--- a/bc/channel/utils/connectors/bluesky.py
+++ b/bc/channel/utils/connectors/bluesky.py
@@ -52,3 +52,6 @@ class BlueskyConnector:
         api_response = self.api.post_status(message, media)
 
         return api_response["cid"]
+
+    def __repr__(self) -> str:
+        return f"<{self.__class__.__module__}.{self.__class__.__name__}: identifier:'{self.identifier}'>"

--- a/bc/channel/utils/connectors/masto.py
+++ b/bc/channel/utils/connectors/masto.py
@@ -21,25 +21,28 @@ masto_regex = re.compile(r"@(.+)@(.+)")
 logger = logging.getLogger(__name__)
 
 
-def get_server_url(handle: str) -> str:
+def get_handle_parts(handle: str) -> tuple[str, str]:
     """
     extracts the server name from the Mastodon handle and returns the URL
     Args:
         handle (str): the mastodon handle
     Returns:
-        str: Mastodon server's URL
+        tuple:
+            str: Mastodon server's URL
+            str: Mastodon handle
     """
     result = masto_regex.search(handle)
     if result:
-        _, instance_part = result.groups()
-        return f"https://{instance_part}/"
-    return ""
+        account_part, instance_part = result.groups()
+        return (account_part, f"https://{instance_part}/")
+    return ("", "")
 
 
 class MastodonConnector:
-    def __init__(self, access_token: str, base_url: str) -> None:
+    def __init__(self, access_token: str, base_url: str, account: str) -> None:
         self.access_token = access_token
         self.base_url = base_url
+        self.account = account
         self.api = self.get_api_object()
 
     def get_api_object(self, _version=None) -> ApiWrapper:
@@ -142,3 +145,6 @@ class MastodonConnector:
         )
 
         return response
+
+    def __repr__(self) -> str:
+        return f"<{self.__class__.__module__}.{self.__class__.__name__}: base_url:'{self.base_url}', account:'{self.account}'>"

--- a/bc/channel/utils/connectors/twitter.py
+++ b/bc/channel/utils/connectors/twitter.py
@@ -11,9 +11,12 @@ from .base import ApiWrapper
 
 
 class TwitterConnector:
-    def __init__(self, access_token: str, access_token_secret: str) -> None:
+    def __init__(
+        self, access_token: str, access_token_secret: str, account: str
+    ) -> None:
         self.access_token = access_token
         self.access_token_secret = access_token_secret
+        self.account = account
         self.api = self.get_api_object("1.1")
         self.api_v2 = self.get_api_object("2")
 
@@ -99,3 +102,6 @@ class TwitterConnector:
         data = response.json()
 
         return data["data"]["id"]
+
+    def __repr__(self) -> str:
+        return f"<{self.__class__.__module__}.{self.__class__.__name__}: account:'{self.account}'>"


### PR DESCRIPTION
Addresses #461 

Also did a little bit of cleanup here. If it's deemed unnecessary let me know and I'll remove it.
- Due to combining the `get_server_url` code and the other mastodon instance splitting code from `self_url`, it is now called `get_handle_parts` and it was moved to the `connectors/mastodon.py` file and tests were updated as well.
- Due to that change I wanted to add tests for `self_url()` to make sure everything worked as expected.
- While doing that it felt proper to have tests for `post_url` as well, which now leverages `self_url` to get its base URL. (Though I wonder if these should be implemented by their connectors instead so we don't have a lot of "business logic" in the channel as we continue to add more channels.

Sorry for the extra rabbit hole of stuff, I got a little carried away. 😆 