### PR TITLE
feat(bluesky): Handle ReadTimeout exceptions during social card creation

### DIFF
--- a/bc/channel/utils/connectors/bluesky_api/client.py
+++ b/bc/channel/utils/connectors/bluesky_api/client.py
@@ -5,7 +5,7 @@ from urllib.parse import urljoin
 
 import requests
 from bs4 import BeautifulSoup
-from requests import HTTPError
+from requests import HTTPError, ReadTimeout
 
 from .types import (
     ImageBlob,
@@ -297,7 +297,7 @@ class BlueskyAPI:
                 timeout=self._timeout,
             )
             resp.raise_for_status()
-        except HTTPError:
+        except (HTTPError, ReadTimeout):
             return None
 
         soup = BeautifulSoup(resp.text, "html.parser")


### PR DESCRIPTION
This PR introduces logic to handle `ReadTimeout` exceptions that may occur during social card creation. When such an exception is encountered, the code will prioritize successfully creating the post itself, ensuring the core functionality remains uninterrupted.

Here's a screenshot of a post with no social card:

![image](https://github.com/freelawproject/bigcases2/assets/55959657/c942b992-0770-4146-804a-37dc072d8905)
