### PR TITLE
feat(bluesky): Updates the Session dataclass

### DIFF
--- a/bc/channel/utils/connectors/bluesky_api/types.py
+++ b/bc/channel/utils/connectors/bluesky_api/types.py
@@ -12,6 +12,8 @@ class Session:
     email: str
     emailConfirmed: bool
     emailAuthFactor: bool
+    active: bool
+    status: str = ""
 
 
 @dataclass


### PR DESCRIPTION
Updates Session class to handle the 'active' and `status` fields in the `createSession` response (related to https://github.com/bluesky-social/atproto/pull/2531).

Fixes #546
