### PR TITLE
feat(deploy): Sync env vars before deployment

### DIFF
--- a/.github/workflows/bulid-and-deploy.yml
+++ b/.github/workflows/bulid-and-deploy.yml
@@ -40,8 +40,8 @@ jobs:
       run: aws eks update-kubeconfig --region ${{ env.AWS_REGION }} --name ${{ env.EKS_CLUSTER_NAME }}
     - name: Update Environment Variables
       env:
-        CL_ENV: bots-env
-      run: kubectl annotate es $CL_ENV force-sync=$(date +%s) --overwrite -n ${{ env.EKS_NAMESPACE }} && kubectl wait es -n ${{ env.EKS_NAMESPACE }} --for=jsonpath="{.status.conditions[?(@.reason=='SecretSynced')].status}"=True --timeout=30s $CL_ENV
+        BOTS_ENV: bots-env
+      run: kubectl annotate es $BOTS_ENV force-sync=$(date +%s) --overwrite -n ${{ env.EKS_NAMESPACE }} && kubectl wait es -n ${{ env.EKS_NAMESPACE }} --for=jsonpath="{.status.conditions[?(@.reason=='SecretSynced')].status}"=True --timeout=30s $BOTS_ENV
     - name: Collect static assets and check unapplied migration exit code
       id: checkMigration
       # Do big complicated thing to get secrets into the image.

--- a/.github/workflows/bulid-and-deploy.yml
+++ b/.github/workflows/bulid-and-deploy.yml
@@ -38,6 +38,10 @@ jobs:
         aws-region: ${{ env.AWS_REGION }}
     - name: Create Kubeconfig with AWS CLI
       run: aws eks update-kubeconfig --region ${{ env.AWS_REGION }} --name ${{ env.EKS_CLUSTER_NAME }}
+    - name: Update Environment Variables
+      env:
+        CL_ENV: bots-env
+      run: kubectl annotate es $CL_ENV force-sync=$(date +%s) --overwrite -n ${{ env.EKS_NAMESPACE }} && kubectl wait es -n ${{ env.EKS_NAMESPACE }} --for=jsonpath="{.status.conditions[?(@.reason=='SecretSynced')].status}"=True --timeout=30s $CL_ENV
     - name: Collect static assets and check unapplied migration exit code
       id: checkMigration
       # Do big complicated thing to get secrets into the image.


### PR DESCRIPTION
New step will apply any update to the Bots.law environment variables before running a restart or creating a new pod.

Secret which holds the vars will be updated and then the step will wait for the secret to have a synced status.

Wait has a limit of 30 seconds which if it's reach, the command will exit with an error status.