### PR TITLE
fix(bluesky): Refines _clean_text method

### DIFF
--- a/bc/channel/utils/connectors/bluesky_api/client.py
+++ b/bc/channel/utils/connectors/bluesky_api/client.py
@@ -214,7 +214,7 @@ class BlueskyAPI:
             str: string containing the original text with all link markup
             notations removed.
         """
-        return re.sub(r"(?<=])\(\S+\)|[\[]|[\]]", "", text)
+        return re.sub(r"\[([^\[\]]*)\]\((.*?)\)", r"\g<1>", text)
 
     def _parse_text_facets(self, text) -> list[TextAnnotation]:
         """


### PR DESCRIPTION
This commit refines the regex pattern to specifically match and remove markup notation associated with embedded links. This ensures that the rest of the post content remains intact, preventing unintended formatting changes.

By making these modifications, we've improved the accuracy and reliability of the text cleaning process, ensuring that embedded links are displayed correctly within Bluesky posts.

Here's a screenshot of one of the post created with this new clean method: 


![image](https://github.com/user-attachments/assets/3115e9c9-9a26-4856-9b69-a1d3c2236cb5)
