### PR TITLE
fix(aws_settings): Add missing variable to production settings

### DIFF
--- a/bc/settings/third_party/aws.py
+++ b/bc/settings/third_party/aws.py
@@ -11,6 +11,7 @@ if DEVELOPMENT:
 else:
     AWS_ACCESS_KEY_ID = env("AWS_ACCESS_KEY_ID", default="")
     AWS_SECRET_ACCESS_KEY = env("AWS_SECRET_ACCESS_KEY", default="")
+    AWS_SESSION_TOKEN = env("AWS_SESSION_TOKEN", default="")
 
 AWS_STORAGE_BUCKET_NAME = env(
     "AWS_STORAGE_BUCKET_NAME", default="law-bots-storage"


### PR DESCRIPTION
The [PR that implements Threads support](https://github.com/freelawproject/bigcases2/pull/618) added a new env variable to support AWS temporary credentials, which requires a session token, but the variable was only set for development so when running in production we get this:

```
cannot import name 'AWS_SESSION_TOKEN' from 'bc.settings' (/opt/bigcases2/bc/settings/__init__.py)
```

This PR solves this issue.