### PR TITLE
feat(Threads): Refresh Threads access tokens automatically.

### DIFF
--- a/bc/channel/models.py
+++ b/bc/channel/models.py
@@ -181,13 +181,12 @@ class Channel(AbstractDateTimeModel):
             )
             raise e
         finally:
-            if lock.owned():
-                try:
-                    lock.release()
-                except Exception as e:
-                    logger.error(
-                        f"Error releasing lock for channel {self}:\n{e}"
-                    )
+            if not lock.owned():
+                return
+            try:
+                lock.release()
+            except Exception as e:
+                logger.error(f"Error releasing lock for channel {self}:\n{e}")
 
     def _refresh_access_token(self):
         api = self.get_api_wrapper()

--- a/bc/channel/models.py
+++ b/bc/channel/models.py
@@ -1,16 +1,25 @@
+import logging
+
 from django.db import models
 from django.urls import reverse
+from redis.exceptions import LockError
 
 from bc.core.models import AbstractDateTimeModel
 from bc.core.utils.color import format_color_str
 from bc.sponsorship.models import Sponsorship
 from bc.users.models import User
 
-from .utils.connectors.base import BaseAPIConnector
+from ..core.utils.redis import make_redis_interface
+from .utils.connectors.base import (
+    BaseAPIConnector,
+    RefreshableBaseAPIConnector,
+)
 from .utils.connectors.bluesky import BlueskyConnector
 from .utils.connectors.masto import MastodonConnector, get_handle_parts
 from .utils.connectors.threads import ThreadsConnector
 from .utils.connectors.twitter import TwitterConnector
+
+logger = logging.getLogger(__name__)
 
 
 class Group(AbstractDateTimeModel):
@@ -70,6 +79,7 @@ class Channel(AbstractDateTimeModel):
         (BLUESKY, "Bluesky"),
         (THREADS, "Threads"),
     )
+    CHANNELS_TO_REFRESH = [THREADS]
     service = models.PositiveSmallIntegerField(
         help_text="Type of the service",
         choices=CHANNELS,
@@ -107,7 +117,9 @@ class Channel(AbstractDateTimeModel):
         blank=True,
     )
 
-    def get_api_wrapper(self) -> BaseAPIConnector:
+    def get_api_wrapper(
+        self,
+    ) -> BaseAPIConnector | RefreshableBaseAPIConnector:
         match self.service:
             case self.TWITTER:
                 return TwitterConnector(
@@ -144,6 +156,45 @@ class Channel(AbstractDateTimeModel):
                 raise NotImplementedError(
                     f"Channel.self_url() not yet implemented for service {self.service}"
                 )
+
+    def validate_access_token(self):
+        if self.service not in self.CHANNELS_TO_REFRESH:
+            return
+        r = make_redis_interface("CACHE")
+        lock_key = self._get_refresh_lock_key()
+        lock = r.lock(lock_key, sleep=1, timeout=60)
+        blocking_timeout = 60
+        try:
+            lock.acquire(blocking=True, blocking_timeout=blocking_timeout)
+            self._refresh_access_token()
+        except LockError as e:
+            logger.error(
+                f"LockError while acquiring lock for channel {self}: {e}"
+            )
+            raise e
+        finally:
+            if lock.owned():
+                try:
+                    lock.release()
+                except Exception as e:
+                    logger.error(
+                        f"Error releasing lock for channel {self}:\n{e}"
+                    )
+
+    def _refresh_access_token(self):
+        api = self.get_api_wrapper()
+        try:
+            refreshed, access_token = api.validate_access_token()
+            if refreshed:
+                self.access_token = access_token
+                self.save()
+        except Exception as e:
+            logger.error(
+                f"Error when trying to refresh token for channel {self.pk}:\n{e}"
+            )
+
+    def _get_refresh_lock_key(self):
+        return f"token_refresh_lock_{self.account_id}@{self.get_service_display()}"
 
     def __str__(self) -> str:
         if self.account:

--- a/bc/channel/models.py
+++ b/bc/channel/models.py
@@ -21,6 +21,8 @@ from .utils.connectors.twitter import TwitterConnector
 
 logger = logging.getLogger(__name__)
 
+r = make_redis_interface("CACHE")
+
 
 class Group(AbstractDateTimeModel):
     name = models.CharField(
@@ -166,7 +168,6 @@ class Channel(AbstractDateTimeModel):
         """
         if self.service not in self.CHANNELS_TO_REFRESH:
             return
-        r = make_redis_interface("CACHE")
         lock_key = self._get_refresh_lock_key()
         lock = r.lock(lock_key, sleep=1, timeout=60)
         blocking_timeout = 60

--- a/bc/channel/signals.py
+++ b/bc/channel/signals.py
@@ -1,5 +1,4 @@
 import logging
-from datetime import timedelta
 
 from django.conf import settings
 from django.db.models.signals import post_save
@@ -11,7 +10,6 @@ from rq import Retry
 from bc.core.utils.cloudfront import create_cache_invalidation
 
 from .models import Channel, Group
-from .tasks import refresh_threads_access_token
 
 queue = get_queue("default")
 
@@ -54,19 +52,4 @@ def channel_handler(sender, instance=None, created=False, **kwargs):
                 max=settings.RQ_MAX_NUMBER_OF_RETRIES,
                 interval=settings.RQ_RETRY_INTERVAL,
             ),
-        )
-
-    # Schedule initial token refresh 2 days after creation
-    if created and instance.service == Channel.THREADS:
-        queue.enqueue_in(
-            timedelta(days=2),
-            refresh_threads_access_token,
-            channel_pk=instance.pk,
-            retry=Retry(
-                max=settings.RQ_MAX_NUMBER_OF_RETRIES,
-                interval=settings.RQ_RETRY_INTERVAL,
-            ),
-        )
-        logger.info(
-            f"Scheduled new refresh token for newly created channel {instance} in 2 days"
         )

--- a/bc/channel/signals.py
+++ b/bc/channel/signals.py
@@ -1,5 +1,3 @@
-import logging
-
 from django.conf import settings
 from django.db.models.signals import post_save
 from django.dispatch import receiver
@@ -12,8 +10,6 @@ from bc.core.utils.cloudfront import create_cache_invalidation
 from .models import Channel, Group
 
 queue = get_queue("default")
-
-logger = logging.getLogger(__name__)
 
 
 @receiver(post_save, sender=Group)

--- a/bc/channel/signals.py
+++ b/bc/channel/signals.py
@@ -1,3 +1,6 @@
+import logging
+from datetime import timedelta
+
 from django.conf import settings
 from django.db.models.signals import post_save
 from django.dispatch import receiver
@@ -8,8 +11,11 @@ from rq import Retry
 from bc.core.utils.cloudfront import create_cache_invalidation
 
 from .models import Channel, Group
+from .tasks import refresh_threads_access_token
 
 queue = get_queue("default")
+
+logger = logging.getLogger(__name__)
 
 
 @receiver(post_save, sender=Group)
@@ -48,4 +54,19 @@ def channel_handler(sender, instance=None, created=False, **kwargs):
                 max=settings.RQ_MAX_NUMBER_OF_RETRIES,
                 interval=settings.RQ_RETRY_INTERVAL,
             ),
+        )
+
+    # Schedule initial token refresh 2 days after creation
+    if created and instance.service == Channel.THREADS:
+        queue.enqueue_in(
+            timedelta(days=2),
+            refresh_threads_access_token,
+            channel_pk=instance.pk,
+            retry=Retry(
+                max=settings.RQ_MAX_NUMBER_OF_RETRIES,
+                interval=settings.RQ_RETRY_INTERVAL,
+            ),
+        )
+        logger.info(
+            f"Scheduled new refresh token for newly created channel {instance} in 2 days"
         )

--- a/bc/channel/tasks.py
+++ b/bc/channel/tasks.py
@@ -92,10 +92,8 @@ def refresh_threads_access_token(channel_pk):
     channel.access_token = new_access_token
     channel.save()
 
-    # Schedule the next token refresh
-    delay_seconds = (
-        expires_in - 86400
-    )  # Subtract one day to avoid expiration before the task runs
+    # Schedule the next token refresh one day before expiration
+    delay_seconds = expires_in - 86400
     queue.enqueue_in(
         timedelta(seconds=delay_seconds if delay_seconds > 0 else expires_in),
         refresh_threads_access_token,

--- a/bc/channel/tasks.py
+++ b/bc/channel/tasks.py
@@ -1,7 +1,5 @@
 import logging
-from datetime import timedelta
 
-import requests
 from django.conf import settings
 from django_rq.queues import get_queue
 from rq import Retry
@@ -44,70 +42,3 @@ def enqueue_text_status_for_group(group: Group, text: str) -> None:
     """
     for channel in group.channels.all():
         enqueue_text_status_for_channel(channel, text)
-
-
-def refresh_threads_access_token(channel_pk):
-    """
-    Task to refresh the access token for a Threads channel.
-    """
-    try:
-        channel = Channel.objects.get(pk=channel_pk)
-    except Channel.DoesNotExist:
-        logger.warning(
-            f"Trying to refresh Threads access token for channel {channel_pk} but it no longer exists."
-        )
-        return
-
-    if channel.service != Channel.THREADS:
-        logger.warning(
-            f"Trying to refresh Threads access token for a {channel.get_service_display()} channel. Aborting."
-        )
-        return
-
-    refresh_access_token_url = "https://graph.threads.net/refresh_access_token"
-    params = {
-        "grant_type": "th_refresh_token",
-        "access_token": channel.access_token,
-    }
-    response = requests.get(
-        refresh_access_token_url,
-        params=params,
-        timeout=10,
-    )
-
-    if response.status_code != 200:
-        logger.error(
-            f"Failed to refresh access token for Threads channel {channel}:"
-            f" {response.status_code} {response.text}"
-        )
-        return
-
-    data = response.json()
-    new_access_token = data.get("access_token")
-    expires_in = data.get("expires_in")  # In seconds
-
-    if new_access_token is None or expires_in is None:
-        logger.error(
-            f"Missing 'access_token' or 'expires_in' in refresh access token response for Threads channel {channel}: {data}\n"
-            f"If the issue persists, a new access token can be retrieved manually with the script again."
-        )
-        return
-
-    channel.access_token = new_access_token
-    channel.save()
-
-    # Schedule the next token refresh one day before expiration
-    delay_seconds = expires_in - 86400
-    queue.enqueue_in(
-        timedelta(seconds=delay_seconds if delay_seconds > 0 else expires_in),
-        refresh_threads_access_token,
-        channel_pk=channel.pk,
-        retry=Retry(
-            max=settings.RQ_MAX_NUMBER_OF_RETRIES,
-            interval=settings.RQ_RETRY_INTERVAL,
-        ),
-    )
-    logger.info(
-        f"Scheduled new refresh token for Threads channel {channel}"
-        f" in {delay_seconds} seconds ({expires_in / 86400:.1f} days)"
-    )

--- a/bc/channel/tasks.py
+++ b/bc/channel/tasks.py
@@ -1,3 +1,7 @@
+import logging
+from datetime import timedelta
+
+import requests
 from django.conf import settings
 from django_rq.queues import get_queue
 from rq import Retry
@@ -5,6 +9,8 @@ from rq import Retry
 from .models import Channel, Group
 
 queue = get_queue("default")
+
+logger = logging.getLogger(__name__)
 
 
 def enqueue_text_status_for_channel(channel: Channel, text: str) -> None:
@@ -38,3 +44,68 @@ def enqueue_text_status_for_group(group: Group, text: str) -> None:
     """
     for channel in group.channels.all():
         enqueue_text_status_for_channel(channel, text)
+
+
+def refresh_threads_access_token(channel_pk):
+    """
+    Task to refresh the access token for a Threads channel.
+    """
+    try:
+        channel = Channel.objects.get(pk=channel_pk)
+    except Channel.DoesNotExist:
+        logger.warning(
+            f"Trying to refresh Threads access token for channel {channel_pk} but it no longer exists."
+        )
+        return
+
+    if channel.service != Channel.THREADS:
+        logger.warning(
+            f"Trying to refresh Threads access token for a {channel.get_service_display()} channel. Aborting."
+        )
+        return
+
+    refresh_access_token_url = "https://graph.threads.net/refresh_access_token"
+    params = {
+        "grant_type": "th_refresh_token",
+        "access_token": channel.access_token,
+    }
+    response = requests.get(refresh_access_token_url, params=params)
+
+    if response.status_code != 200:
+        logger.error(
+            f"Failed to refresh access token for Threads channel {channel}:"
+            f" {response.status_code} {response.text}"
+        )
+        return
+
+    data = response.json()
+    new_access_token = data.get("access_token")
+    expires_in = data.get("expires_in")  # In seconds
+
+    if new_access_token is None or expires_in is None:
+        logger.error(
+            f"Missing 'access_token' or 'expires_in' in refresh access token response for Threads channel {channel}: {data}\n"
+            f"If the issue persists, a new access token can be retrieved manually with the script again."
+        )
+        return
+
+    channel.access_token = new_access_token
+    channel.save()
+
+    # Schedule the next token refresh
+    delay_seconds = (
+        expires_in - 86400
+    )  # Subtract one day to avoid expiration before the task runs
+    queue.enqueue_in(
+        timedelta(seconds=delay_seconds if delay_seconds > 0 else expires_in),
+        refresh_threads_access_token,
+        channel_pk=channel.pk,
+        retry=Retry(
+            max=settings.RQ_MAX_NUMBER_OF_RETRIES,
+            interval=settings.RQ_RETRY_INTERVAL,
+        ),
+    )
+    logger.info(
+        f"Scheduled new refresh token for Threads channel {channel}"
+        f" in {delay_seconds} seconds ({expires_in / 86400:.1f} days)"
+    )

--- a/bc/channel/tasks.py
+++ b/bc/channel/tasks.py
@@ -69,7 +69,11 @@ def refresh_threads_access_token(channel_pk):
         "grant_type": "th_refresh_token",
         "access_token": channel.access_token,
     }
-    response = requests.get(refresh_access_token_url, params=params)
+    response = requests.get(
+        refresh_access_token_url,
+        params=params,
+        timeout=10,
+    )
 
     if response.status_code != 200:
         logger.error(

--- a/bc/channel/tasks.py
+++ b/bc/channel/tasks.py
@@ -16,6 +16,7 @@ def enqueue_text_status_for_channel(channel: Channel, text: str) -> None:
         channel (Channel): The channel object.
         text (str): Message for the new status.
     """
+    channel.validate_access_token()
     api = channel.get_api_wrapper()
     queue.enqueue(
         api.add_status,

--- a/bc/channel/tasks.py
+++ b/bc/channel/tasks.py
@@ -1,5 +1,3 @@
-import logging
-
 from django.conf import settings
 from django_rq.queues import get_queue
 from rq import Retry
@@ -7,8 +5,6 @@ from rq import Retry
 from .models import Channel, Group
 
 queue = get_queue("default")
-
-logger = logging.getLogger(__name__)
 
 
 def enqueue_text_status_for_channel(channel: Channel, text: str) -> None:

--- a/bc/channel/utils/connectors/base.py
+++ b/bc/channel/utils/connectors/base.py
@@ -73,4 +73,17 @@ class BaseAPIConnector(Protocol):
 
 
 class RefreshableBaseAPIConnector(BaseAPIConnector, Protocol):
-    def validate_access_token(self) -> tuple[bool, str]: ...
+    """
+    Extends BaseAPIConnector to add logic to validate access tokens.
+    """
+
+    def validate_access_token(self) -> tuple[bool, str]:
+        """
+        Validates the access token and refreshes it if necessary.
+
+        Returns:
+            tuple[bool, str]: A tuple where the first element is a boolean
+             indicating if the token was refreshed, and the second element
+             is the current access token.
+        """
+        ...

--- a/bc/channel/utils/connectors/base.py
+++ b/bc/channel/utils/connectors/base.py
@@ -70,3 +70,7 @@ class BaseAPIConnector(Protocol):
             int: The unique identifier for the new status.
         """
         ...
+
+
+class RefreshableBaseAPIConnector(BaseAPIConnector, Protocol):
+    def validate_access_token(self) -> tuple[bool, str]: ...

--- a/bc/channel/utils/connectors/threads.py
+++ b/bc/channel/utils/connectors/threads.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 class ThreadsConnector:
     """
     A connector for interfacing with the Threads API, which complies with
-    the BaseAPIConnector protocol.
+    the RefreshableBaseAPIConnector protocol.
     """
 
     def __init__(
@@ -31,6 +31,9 @@ class ThreadsConnector:
             self.access_token,
         )
         return api
+
+    def validate_access_token(self) -> tuple[bool, str]:
+        return self.api.validate_access_token()
 
     def upload_media(self, media: bytes, _alt_text=None) -> str:
         """

--- a/bc/channel/utils/connectors/threads.py
+++ b/bc/channel/utils/connectors/threads.py
@@ -33,6 +33,17 @@ class ThreadsConnector:
         return api
 
     def validate_access_token(self) -> tuple[bool, str]:
+        """
+        Ensures that the access token used by the connector is up-to-date.
+
+        This method delegates the validation of the access token to the underlying
+        `ThreadsAPI` instance by checking the access token's expiration date and
+        refreshing it if necessary.
+
+        Returns:
+            tuple[bool, str]: A tuple where the first element is a boolean
+             indicating whether the token was refreshed, and the second element is the current access token.
+        """
         return self.api.validate_access_token()
 
     def upload_media(self, media: bytes, _alt_text=None) -> str:

--- a/bc/channel/utils/connectors/threads_api/client.py
+++ b/bc/channel/utils/connectors/threads_api/client.py
@@ -14,6 +14,8 @@ logger = logging.getLogger(__name__)
 
 _BASE_API_URL = "https://graph.threads.net/v1.0"
 
+r = make_redis_interface("CACHE")
+
 
 class ThreadsAPI:
     """
@@ -178,7 +180,6 @@ class ThreadsAPI:
             tuple[bool, str]: A tuple where the first element is a boolean
              indicating whether the token was refreshed, and the second element is the current access token.
         """
-        r = make_redis_interface("CACHE")
         refreshed = False
 
         try:
@@ -258,7 +259,6 @@ class ThreadsAPI:
         """
         delay = timedelta(seconds=expires_in)
         expiration_date = (datetime.now(timezone.utc) + delay).isoformat()
-        r = make_redis_interface("CACHE")
         key = self._get_expiration_key()
         try:
             r.set(

--- a/bc/subscription/tasks.py
+++ b/bc/subscription/tasks.py
@@ -110,6 +110,7 @@ def enqueue_posts_for_new_case(
             initial_complaint_link=initial_complaint_link,
         )
 
+        channel.validate_access_token()
         api = channel.get_api_wrapper()
 
         sponsor_message = None
@@ -422,6 +423,8 @@ def make_post_for_webhook_event(
 
     if sponsor_text and files:
         files = add_sponsored_text_to_thumbnails(files, sponsor_text)
+
+    channel.validate_access_token()
 
     api = channel.get_api_wrapper()
     api_post_id = api.add_status(message, image, files)

--- a/scripts/get-threads-keys.py
+++ b/scripts/get-threads-keys.py
@@ -50,6 +50,7 @@ def main():
             "grant_type": "authorization_code",
             "redirect_uri": THREADS_CALLBACK,
         },
+        timeout=10,
     )
 
     if response.status_code != 200:
@@ -67,7 +68,11 @@ def main():
         "client_secret": APP_SECRET,
         "access_token": short_lived_access_token,
     }
-    response = requests.get(LONG_LIVED_ACCESS_TOKEN_URL, params=params)
+    response = requests.get(
+        LONG_LIVED_ACCESS_TOKEN_URL,
+        params=params,
+        timeout=10,
+    )
 
     if response.status_code != 200:
         raise Exception(
@@ -79,7 +84,10 @@ def main():
     expires_in = long_lived_data.get("expires_in")
 
     user_info_url = f"{USER_INFO_BASE_URL}/{user_id}?fields=username&access_token={long_access_token}"
-    response = requests.get(user_info_url)
+    response = requests.get(
+        user_info_url,
+        timeout=10,
+    )
 
     if response.status_code != 200:
         raise Exception(


### PR DESCRIPTION
Resolves #627 

Long-lived tokens need to be at least 24 hours old to be refreshed so upon creation of a new Threads channel, a `post_save` signal enqueues a job to refresh the token in 2 days. After that, we enqueue a new job in as many seconds as the `expires_in` value from the token refresh response.