### PR TITLE
feat(header): comment out GivingTuesday banner

### DIFF
--- a/bc/assets/templates/includes/header.html
+++ b/bc/assets/templates/includes/header.html
@@ -1,19 +1,19 @@
 {% load static web_extras %}
 
-<div class="flex w-full justify-center items-center py-2 border-b-2 border-gray-400">
-  <div class="flex lg:flex-row flex-col justify-center items-center p-3 text-center">
-    <strong class="pr-2">Today is GivingTuesday.</strong>
-    <span class="text-sm pr-2 mb-2 lg:mb-0">
-      Your support of Free Law Project helps make the justice system more transparent and accessible to all.
-    </span>
-    <a href="https://donate.free.law/forms/givingtuesday" class="underline hidden md:block">
-      Donate Today!
-    </a>
-    <div class="w-28 text-sm font-medium mr-1 md:hidden">
-      {% include './action-button.html' with link="https://donate.free.law/forms/supportflp" text="Donate Today!" size='sm' color='saffron' %}
-    </div>
-  </div>
-</div>
+{#<div class="flex w-full justify-center items-center py-2 border-b-2 border-gray-400">#}
+{#  <div class="flex lg:flex-row flex-col justify-center items-center p-3 text-center">#}
+{#    <strong class="pr-2">Today is GivingTuesday.</strong>#}
+{#    <span class="text-sm pr-2 mb-2 lg:mb-0">#}
+{#      Your support of Free Law Project helps make the justice system more transparent and accessible to all.#}
+{#    </span>#}
+{#    <a href="https://donate.free.law/forms/givingtuesday" class="underline hidden md:block">#}
+{#      Donate Today!#}
+{#    </a>#}
+{#    <div class="w-28 text-sm font-medium mr-1 md:hidden">#}
+{#      {% include './action-button.html' with link="https://donate.free.law/forms/supportflp" text="Donate Today!" size='sm' color='saffron' %}#}
+{#    </div>#}
+{#  </div>#}
+{#</div>#}
 
 <div class="relative bg-gray-200 border-b-2 border-gray-400">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 md:px-10">


### PR DESCRIPTION
Closes #640 

This is a temporary fix to hide the banner, but it should be the last time we need to change the code to toggle this since we're adding a setting for it [here](https://github.com/freelawproject/bigcases2/issues/641)