### PR TITLE
feat(core): Invalidate cache after saving banners

### DIFF
--- a/bc/core/apps.py
+++ b/bc/core/apps.py
@@ -1,0 +1,9 @@
+from django.apps import AppConfig
+
+
+class UsersConfig(AppConfig):
+    name = "bc.core"
+
+    def ready(self):
+        # Implicitly connect a signal handlers decorated with @receiver.
+        from bc.core import signals

--- a/bc/core/signals.py
+++ b/bc/core/signals.py
@@ -1,0 +1,24 @@
+from django.conf import settings
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+from django_rq.queues import get_queue
+from rq import Retry
+
+from bc.core.utils.cloudfront import create_cache_invalidation
+
+from .models import BannerConfig
+
+queue = get_queue("default")
+
+
+@receiver(post_save, sender=BannerConfig)
+def bannerconfig_handler(sender, instance=None, created=False, **kwargs):
+    if settings.AWS_CLOUDFRONT_DISTRIBUTION_ID and not settings.DEVELOPMENT:
+        queue.enqueue(
+            create_cache_invalidation,
+            "/*",
+            retry=Retry(
+                max=settings.RQ_MAX_NUMBER_OF_RETRIES,
+                interval=settings.RQ_RETRY_INTERVAL,
+            ),
+        )


### PR DESCRIPTION
This PR addresses #646 by using the post-save signal to invalidate the cache whenever a BannerConfig object is saved or updated.




