### PR TITLE
build(poetry): set poetry packaging-mode to false

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ name = "Big Cases Bot 2"
 readme = "README.md"
 repository = "https://github.com/freelawproject/bigcases2"
 version = "0.0.1"
+package-mode = false
 
 [tool.poetry.urls]
 "Organisation Homepage" = "https://free.law/"


### PR DESCRIPTION
We're only using Poetry for dependency management and not for packaging the project, but Poetry has always attempted and failed to package it with a warning ([see an example here](https://github.com/freelawproject/bigcases2/actions/runs/12568106838/job/35035311609#step:7:131)). Newer versions of Poetry now throw an error instead of a warning, so a few days ago pipelines started failing. This PR fixes that by preventing Poetry from attempting to package the project.
