### PR TITLE
build(poetry): bump Poetry version used in Dockerfile

### DIFF
--- a/docker/django/Dockerfile
+++ b/docker/django/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update --option "Acquire::Retries=3" --quiet=2 && \
 
 # poetry
 # https://python-poetry.org/docs/configuration/#using-environment-variables
-ENV POETRY_VERSION=1.3.2 \
+ENV POETRY_VERSION=2.0.0 \
     # make poetry install to this location
     POETRY_HOME="/opt/poetry" \
     # Don't build a virtualenv to save space
@@ -43,7 +43,7 @@ FROM build-base as python-base
 WORKDIR $PYSETUP_PATH
 
 COPY poetry.lock pyproject.toml ./
-RUN poetry install --no-root $(test "$BUILD_ENV" != "dev" && echo "--without dev")
+RUN poetry install $(test "$BUILD_ENV" != "dev" && echo "--without dev")
 
 COPY . /opt/bigcases2
 


### PR DESCRIPTION
Updated to latest version (2.0.0) that supports new property `package-mode = false`, so we don't need to pass the `--no-root` flag when installing dependencies anymore. This is the same version used by our checks as they use a github action that [defaults to latest](https://github.com/snok/install-poetry#defaults).

The `package-mode = false` property was added to `pyproject.toml` in [this PR](https://github.com/freelawproject/bigcases2/pull/652), after which the build failed due to the old Poetry version used in the Dockerfile, hence this PR was created.


More info on Poetry's new property [here](https://github.com/python-poetry/poetry/pull/8650).