### PR TITLE
chore: Move formatting and linting to Ruff

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,12 +18,7 @@ updates:
   ignore:
   # Ignore all tooling (it can get old, it's mature enough)
   - dependency-name: selenium
-  - dependency-name: black
-  - dependency-name: pylint
-  - dependency-name: flake8
-  - dependency-name: isort
   - dependency-name: mypy
-  - dependency-name: flynt
   # Ignore all patch updates.
   - dependency-name: '*'
     update-types: ["version-update:semver-patch"]

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,6 +17,8 @@ jobs:
         with:
           python-version: "3.11"
 
+      - uses: pre-commit/action@v3.0.0
+
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
@@ -50,25 +52,3 @@ jobs:
           --follow-imports=skip \
           --exclude 'migrations/*' \
           .
-
-      - name: Flynt f-string Formatter
-        run: >
-          flynt .
-          --line-length=79
-          --transform-concats
-          --fail-on-change
-
-      - name: Black Code Formatter
-        uses: psf/black@stable
-
-  lint-isort:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.9"
-
-      - name: isort Import Sorter
-        uses: isort/isort-action@v1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,28 +24,12 @@ repos:
      - id: trailing-whitespace
        args: [--markdown-linebreak-ext=md]
 
-  - repo: https://github.com/ikamensh/flynt/
-    rev: '1.0.1'
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.8
     hooks:
-     - id: flynt
-       args: [--line-length=79, --transform-concats]
-
-  - repo: https://github.com/psf/black
-    rev: 25.1.0
-    hooks:
-     - id: black
-
-  - repo: https://github.com/PyCQA/isort
-    rev: 6.0.1
-    hooks:
-     - id: isort
-       name: isort (python)
-
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.19.1
-    hooks:
-     - id: pyupgrade
-       args: [--py311-plus]
+      - id: ruff
+        args: [ --fix ]
+      - id: ruff-format
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.15.0
@@ -69,12 +53,3 @@ repos:
           twitterapi==2.8.2,
           types-requests==2.31.0.1,
         ]
-
-#
-# Tried and Failed
-#
-# 1. I tried doing mypy too, but it was a mess because it runs in its own
-#   isolated environment, that lacks all our dependencies.
-# 2. We might want flake8 someday. It's easy to turn on, but it's so noisy on
-#    our current code that it'd take some fine-tuning to get it right.
-# 3. semgrep was too slow and had to be moved to a github action.

--- a/bc/channel/apps.py
+++ b/bc/channel/apps.py
@@ -6,4 +6,4 @@ class UsersConfig(AppConfig):
 
     def ready(self):
         # Implicitly connect a signal handlers decorated with @receiver.
-        from bc.channel import signals
+        from bc.channel import signals  # noqa: F401

--- a/bc/channel/tests/test_bluesky_connector.py
+++ b/bc/channel/tests/test_bluesky_connector.py
@@ -3,10 +3,8 @@ from unittest.mock import call, patch
 from django.test import SimpleTestCase
 
 from bc.channel.tests.factories import fake_token
-from bc.channel.utils.connectors import bluesky
 from bc.channel.utils.connectors.alt_text_utils import thumb_num_alt_text
 from bc.channel.utils.connectors.bluesky import BlueskyConnector
-from bc.channel.utils.connectors.bluesky_api.client import _BASE_API_URL
 from bc.core.utils.tests.base import faker
 
 

--- a/bc/channel/tests/test_twitter_connector.py
+++ b/bc/channel/tests/test_twitter_connector.py
@@ -5,7 +5,6 @@ from django.test import SimpleTestCase
 from bc.channel.tests.factories import fake_token
 from bc.channel.utils.connectors.twitter import TwitterConnector
 from bc.core.utils.tests.base import faker
-from bc.settings.third_party import twitter
 
 
 class UploadMediaTest(SimpleTestCase):

--- a/bc/channel/utils/connectors/threads_api/client.py
+++ b/bc/channel/utils/connectors/threads_api/client.py
@@ -155,8 +155,7 @@ class ThreadsAPI:
             response.raise_for_status()
         except requests.exceptions.Timeout:
             logger.error(
-                f"Post request to Threads API timed out\n"
-                f"Request URL: {url}"
+                f"Post request to Threads API timed out\nRequest URL: {url}"
             )
             return None
         except requests.exceptions.HTTPError as err:

--- a/bc/core/apps.py
+++ b/bc/core/apps.py
@@ -6,4 +6,4 @@ class UsersConfig(AppConfig):
 
     def ready(self):
         # Implicitly connect a signal handlers decorated with @receiver.
-        from bc.core import signals
+        from bc.core import signals  # noqa: F401

--- a/bc/core/management/commands/bootstrap-dev.py
+++ b/bc/core/management/commands/bootstrap-dev.py
@@ -44,12 +44,12 @@ class Command(VerboseCommand):
             "-r",
             type=int,
             action="append",
-            help=f"Create a subscription with data from a "
-            f"real case in Court Listener with the "
-            f"Court Listener docket id (integer) that you provide."
-            f"  This will be subscribed as a big case.  "
-            f"You can use this option multiple times to  subscribe to "
-            f"multiple cases. Ex: --real-case 67490069 --real-case 67490070",
+            help="Create a subscription with data from a "
+            "real case in Court Listener with the "
+            "Court Listener docket id (integer) that you provide."
+            "  This will be subscribed as a big case.  "
+            "You can use this option multiple times to  subscribe to "
+            "multiple cases. Ex: --real-case 67490069 --real-case 67490070",
         )
 
     def handle(self, *args, **options) -> None:

--- a/bc/core/management/commands/command_utils.py
+++ b/bc/core/management/commands/command_utils.py
@@ -12,9 +12,7 @@ class VerboseCommand(BaseCommand):
 
     def handle(self, *args, **options):
         verbosity = options.get("verbosity")
-        if not verbosity:
-            self.logger.setLevel(logging.WARN)
-        elif verbosity == 0:
+        if not verbosity or verbosity == 0:
             self.logger.setLevel(logging.WARN)
         elif verbosity == 1:  # default
             self.logger.setLevel(logging.INFO)

--- a/bc/core/management/commands/make_dev_data.py
+++ b/bc/core/management/commands/make_dev_data.py
@@ -238,7 +238,7 @@ class MakeDevData:
         )
         return subs, self._made_str(
             num,
-            f"{info} {docket_ids}" f"\n{self.INDENT_STR}{subd_to_big_cases}",
+            f"{info} {docket_ids}\n{self.INDENT_STR}{subd_to_big_cases}",
         )
 
     def make_random_subscriptions(

--- a/bc/core/models.py
+++ b/bc/core/models.py
@@ -1,5 +1,4 @@
 from django.db import models
-from django.db.models import Q
 
 
 class AbstractDateTimeModel(models.Model):
@@ -22,7 +21,6 @@ class AbstractDateTimeModel(models.Model):
 
 
 class BannerConfig(models.Model):
-
     is_active = models.BooleanField(
         default=False,
         help_text="If another config is currently active, enabling this one will deactivate the first one.",

--- a/bc/core/templatetags/web_extras.py
+++ b/bc/core/templatetags/web_extras.py
@@ -1,5 +1,5 @@
 from django import template
-from django.utils.safestring import SafeString, mark_safe
+from django.utils.safestring import mark_safe
 
 register = template.Library()
 

--- a/bc/core/tests/test_make_dev_data.py
+++ b/bc/core/tests/test_make_dev_data.py
@@ -395,7 +395,7 @@ class NumSubdToGroupStrTest(SimpleTestCase):
         self, num: int = 0, group_str: str = "", actual_str=""
     ):
         expected_indented_subcribed = (
-            f"  {num} subscribed to group" f" {group_str}"
+            f"  {num} subscribed to group {group_str}"
         )
         self.assertRegex(actual_str, re.compile(expected_indented_subcribed))
 

--- a/bc/core/tests/test_templates.py
+++ b/bc/core/tests/test_templates.py
@@ -745,8 +745,7 @@ class MastodonTemplateTest(SimpleTestCase):
             self.assertEqual(
                 result,
                 test["length"],
-                msg="Failed with dict: %s.\n%s is longer than %s"
-                % (test, result, test["length"]),
+                msg=f"Failed with dict: {test}.\n{result} is longer than {test['length']}",
             )
 
     def test_compute_length_of_template_with_links(self):
@@ -786,8 +785,7 @@ class MastodonTemplateTest(SimpleTestCase):
             self.assertEqual(
                 result,
                 test["length"],
-                msg="Failed with dict: %s.\n%s is longer than %s"
-                % (test, result, test["length"]),
+                msg=f"Failed with dict: {test}.\n{result} is longer than {test['length']}",
             )
 
     def test_truncate_descriptions(self):
@@ -807,13 +805,11 @@ class MastodonTemplateTest(SimpleTestCase):
             result, _ = template.format(**test)
             self.assertTrue(
                 len(result) <= template.max_characters,
-                msg="Failed with dict: %s.\n%s is longer than %s"
-                % (test, result, template.max_characters),
+                msg=f"Failed with dict: {test}.\n{result} is longer than {template.max_characters}",
             )
 
 
 class BlueskyTemplateTest(SimpleTestCase):
-
     @patch(
         "bc.channel.utils.connectors.bluesky_api.client.BlueskyAPI._get_session"
     )

--- a/bc/core/tests/test_text_images.py
+++ b/bc/core/tests/test_text_images.py
@@ -54,8 +54,7 @@ class TextImageTest(SimpleTestCase):
             self.assertLessEqual(
                 instance.width,
                 instance.max_width,
-                msg="Failed with dict: %s.\n%s is larger than %s"
-                % (test, instance.width, instance.max_width),
+                msg=f"Failed with dict: {test}.\n{instance.width} is larger than {instance.max_width}",
             )
 
             # compute the max number of character to render in each line

--- a/bc/core/utils/context_processors.py
+++ b/bc/core/utils/context_processors.py
@@ -1,5 +1,3 @@
-from django.conf import settings
-
 from bc.core.models import BannerConfig
 
 

--- a/bc/core/utils/images.py
+++ b/bc/core/utils/images.py
@@ -458,7 +458,6 @@ def convert_to_jpeg(
 ) -> bytes:
     # Load the image from bytes
     with Image.open(io.BytesIO(image)) as img:
-
         # Ensure image is in RGB mode (JPEG requirement, no transparency)
         if img.mode != "RGB":
             img = img.convert("RGB")

--- a/bc/core/utils/microservices.py
+++ b/bc/core/utils/microservices.py
@@ -20,7 +20,7 @@ def get_thumbnails_from_range(document: bytes, page_range: str) -> list[bytes]:
     thumbnails = requests.post(
         f"{settings.DOCTOR_HOST}/convert/pdf/thumbnails/",
         data={"pages": page_range, "max_dimension": "1920"},
-        files={"file": (f"dummy.pdf", document)},
+        files={"file": ("dummy.pdf", document)},
         timeout=60,
     )
 

--- a/bc/core/utils/status/base.py
+++ b/bc/core/utils/status/base.py
@@ -6,9 +6,8 @@ from django.template import Context, NodeList, Template
 from django.template.base import VariableNode
 from django.template.defaulttags import IfNode
 
+from bc.core.utils.images import TextImage
 from bc.core.utils.string_utils import trunc
-
-from ..images import TextImage
 
 
 class InvalidTemplate(Exception):

--- a/bc/settings/__init__.py
+++ b/bc/settings/__init__.py
@@ -1,15 +1,15 @@
-from .django import *
-from .misc import *
-from .project.email import *
-from .project.security import *
-from .project.testing import *
-from .third_party.aws import *
-from .third_party.courtlistener import *
-from .third_party.hcaptcha import *
-from .third_party.mastodon import *
-from .third_party.pacer import *
-from .third_party.redis import *
-from .third_party.rq import *
-from .third_party.sentry import *
-from .third_party.threads import *
-from .third_party.twitter import *
+from .django import *  # noqa: F403
+from .misc import *  # noqa: F403
+from .project.email import *  # noqa: F403
+from .project.security import *  # noqa: F403
+from .project.testing import *  # noqa: F403
+from .third_party.aws import *  # noqa: F403
+from .third_party.courtlistener import *  # noqa: F403
+from .third_party.hcaptcha import *  # noqa: F403
+from .third_party.mastodon import *  # noqa: F403
+from .third_party.pacer import *  # noqa: F403
+from .third_party.redis import *  # noqa: F403
+from .third_party.rq import *  # noqa: F403
+from .third_party.sentry import *  # noqa: F403
+from .third_party.threads import *  # noqa: F403
+from .third_party.twitter import *  # noqa: F403

--- a/bc/settings/project/security.py
+++ b/bc/settings/project/security.py
@@ -2,10 +2,9 @@ import socket
 
 import environ
 
-from ..django import DEVELOPMENT, INSTALLED_APPS, TESTING
-from ..project.testing import TESTING
-from ..third_party.aws import AWS_S3_CUSTOM_DOMAIN
-from ..third_party.sentry import SENTRY_REPORT_URI
+from bc.settings.django import DEVELOPMENT, INSTALLED_APPS
+from bc.settings.project.testing import TESTING
+from bc.settings.third_party.aws import AWS_S3_CUSTOM_DOMAIN
 
 env = environ.FileAwareEnv()
 

--- a/bc/settings/third_party/hcaptcha.py
+++ b/bc/settings/third_party/hcaptcha.py
@@ -1,8 +1,8 @@
 import environ
 
-env = environ.FileAwareEnv()
+from bc.settings.project.testing import TESTING
 
-from ..project.testing import TESTING
+env = environ.FileAwareEnv()
 
 if TESTING:
     HCAPTCHA_SITEKEY = "10000000-ffff-ffff-ffff-000000000001"

--- a/bc/settings/third_party/rq.py
+++ b/bc/settings/third_party/rq.py
@@ -1,9 +1,10 @@
 import environ
 
-env = environ.FileAwareEnv()
+from bc.settings.project.testing import TESTING
 
-from ..project.testing import TESTING
 from .redis import REDIS_DATABASES, REDIS_HOST, REDIS_PORT
+
+env = environ.FileAwareEnv()
 
 RQ_SHOW_ADMIN_LINK = True
 

--- a/bc/sponsorship/apps.py
+++ b/bc/sponsorship/apps.py
@@ -6,4 +6,4 @@ class UsersConfig(AppConfig):
 
     def ready(self):
         # Implicitly connect a signal handlers decorated with @receiver.
-        from bc.sponsorship import signals
+        from bc.sponsorship import signals  # noqa: F401

--- a/bc/sponsorship/models.py
+++ b/bc/sponsorship/models.py
@@ -56,8 +56,7 @@ class Transaction(AbstractDateTimeModel):
         on_delete=models.PROTECT,
     )
     type = models.SmallIntegerField(
-        help_text="The type of the transaction. Possible values "
-        "are: %s" % ", ".join([f"({t[0]}): {t[1]}" for t in TYPES]),
+        help_text=f"The type of the transaction. Possible values are: {', '.join([f'({t[0]}): {t[1]}' for t in TYPES])}",
         default=SPONSORSHIP,
         choices=TYPES,
     )

--- a/bc/sponsorship/services.py
+++ b/bc/sponsorship/services.py
@@ -36,7 +36,9 @@ def log_purchase(
     """
     # Gets the ids of the active sponsorships from each sponsor group.
     sponsorship_ids: list[int] = [
-        group.sponsorships.first().pk for group in sponsored_groups if group.sponsorships.count()  # type: ignore
+        group.sponsorships.first().pk  # type: ignore [misc,union-attr]
+        for group in sponsored_groups
+        if group.sponsorships.count()
     ]
     sponsorships = get_sponsorships_for_subscription(
         sponsorship_ids, subscription_pk

--- a/bc/subscription/admin.py
+++ b/bc/subscription/admin.py
@@ -1,7 +1,5 @@
 from django.contrib import admin
 
-from bc.channel.models import Channel
-
 from .models import FilingWebhookEvent, Subscription
 
 

--- a/bc/subscription/apps.py
+++ b/bc/subscription/apps.py
@@ -6,4 +6,4 @@ class UsersConfig(AppConfig):
 
     def ready(self):
         # Implicitly connect a signal handlers decorated with @receiver.
-        from bc.subscription import signals
+        from bc.subscription import signals  # noqa: F401

--- a/bc/subscription/models.py
+++ b/bc/subscription/models.py
@@ -172,8 +172,7 @@ class FilingWebhookEvent(AbstractDateTimeModel):
         null=True,
     )
     status = models.SmallIntegerField(
-        help_text="The current status of this upload. Possible values "
-        "are: %s" % ", ".join([f"({t[0]}): {t[1]}" for t in CHOICES]),
+        help_text=f"The current status of this upload. Possible values are: {', '.join([f'({t[0]}): {t[1]}' for t in CHOICES])}",
         default=SCHEDULED,
         choices=CHOICES,
     )

--- a/bc/subscription/utils/courtlistener.py
+++ b/bc/subscription/utils/courtlistener.py
@@ -26,9 +26,10 @@ PDF_URL_PATTERN = re.compile(
     r"(?P<url_for_redirect>(https:\/{2}storage\.courtlistener\.com\/recap\/gov.uscourts.(?P<court>[a-z]+).(?P<pacer_case_id>\d+)))(?:\/.*)"
 )
 
-CL_API_URL = (
-    lambda suffix: f"https://www.courtlistener.com/api/rest/v4/{suffix}/"
-)
+
+def CL_API_URL(suffix):
+    return f"https://www.courtlistener.com/api/rest/v4/{suffix}/"
+
 
 CL_MEDIA_STORAGE = "https://storage.courtlistener.com/"
 

--- a/bc/subscription/views.py
+++ b/bc/subscription/views.py
@@ -85,7 +85,9 @@ class AddCaseView(LoginRequiredMixin, View):
         docket["case_summary"] = cd["case_summary"]
         docket["article_url"] = cd["article_url"]
         try:
-            with transaction.atomic():  # Inner atomic block, create a savepoint
+            with (
+                transaction.atomic()
+            ):  # Inner atomic block, create a savepoint
                 (
                     subscription,
                     created,

--- a/bc/users/apps.py
+++ b/bc/users/apps.py
@@ -6,4 +6,4 @@ class UsersConfig(AppConfig):
 
     def ready(self):
         # Implicitly connect a signal handlers decorated with @receiver.
-        from bc.users import signals
+        from bc.users import signals  # noqa: F401

--- a/bc/users/signals.py
+++ b/bc/users/signals.py
@@ -1,9 +1,6 @@
-from datetime import timedelta
-
 from django.conf import settings
 from django.db.models.signals import post_save
 from django.dispatch import receiver
-from django.utils.timezone import now
 
 
 @receiver(

--- a/bc/users/tests/test_views.py
+++ b/bc/users/tests/test_views.py
@@ -21,8 +21,8 @@ class UserTest(LiveServerTestCase):
             self.assertEqual(
                 r.status_code,
                 HTTPStatus.OK,
-                msg="Got wrong status code for page at: {path}. "
-                "Status Code: {code}".format(path=path, code=r.status_code),
+                msg=f"Got wrong status code for page at: {path}. "
+                f"Status Code: {r.status_code}",
             )
 
     async def test_login_redirects(self) -> None:
@@ -61,17 +61,15 @@ class UserTest(LiveServerTestCase):
                     self.assertNotIn(
                         f'value="{next_param}"',
                         response.content.decode(),
-                        msg="'%s' found in HTML of response. This suggests it was "
-                        "not cleaned by the sanitize_redirection function."
-                        % next_param,
+                        msg=f"'{next_param}' found in HTML of response. This suggests it was "
+                        "not cleaned by the sanitize_redirection function.",
                     )
                 else:
                     self.assertIn(
                         f'value="{next_param}"',
                         response.content.decode(),
-                        msg="'%s' not found in HTML of response. This suggests it "
-                        "was sanitized when it should not have been."
-                        % next_param,
+                        msg=f"'{next_param}' not found in HTML of response. This suggests it "
+                        "was sanitized when it should not have been.",
                     )
 
     async def test_prevent_text_injection_in_success_registration(self):
@@ -99,16 +97,15 @@ class UserTest(LiveServerTestCase):
                     self.assertNotIn(
                         email,
                         response.content.decode(),
-                        msg="'%s' found in HTML of response. This indicates a "
+                        msg=f"'{email}' found in HTML of response. This indicates a "
                         "potential security vulnerability. The view likely "
-                        "failed to properly validate it." % email,
+                        "failed to properly validate it.",
                     )
                 else:
                     self.assertIn(
                         email,
                         response.content.decode(),
-                        msg="'%s' not found in HTML of response. This suggests a "
+                        msg=f"'{email}' not found in HTML of response. This suggests a "
                         "a potential issue with the validation logic. The email "
-                        "address may have been incorrectly identified as invalid"
-                        % email,
+                        "address may have been incorrectly identified as invalid",
                     )

--- a/bc/users/utils/email.py
+++ b/bc/users/utils/email.py
@@ -90,8 +90,7 @@ emails: dict[str, EmailType] = {
     # Used both when people want to confirm an email address and when they
     # want to reset their password, with one small tweak in the wording.
     "no_account_found": {
-        "subject": "Password reset and username information on "
-        "Bots.law.com",
+        "subject": "Password reset and username information on Bots.law.com",
         "body": "Hello,\n\n"
         ""
         "Somebody — probably you — has asked that we send %s "

--- a/bc/users/views.py
+++ b/bc/users/views.py
@@ -17,7 +17,6 @@ from django.shortcuts import redirect, render
 from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.utils.http import urlencode
-from django.utils.timezone import now
 from django.views.decorators.cache import never_cache
 from django.views.decorators.debug import (
     sensitive_post_parameters,

--- a/poetry.lock
+++ b/poetry.lock
@@ -107,34 +107,6 @@ files = [
 tests = ["mypy (>=0.800)", "pytest", "pytest-asyncio"]
 
 [[package]]
-name = "astor"
-version = "0.8.1"
-description = "Read/rewrite/write Python ASTs"
-optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
-groups = ["dev"]
-files = [
-    {file = "astor-0.8.1-py2.py3-none-any.whl", hash = "sha256:070a54e890cefb5b3739d19f30f5a5ec840ffc9c50ffa7d23cc9fc1a38ebbfc5"},
-    {file = "astor-0.8.1.tar.gz", hash = "sha256:6a6effda93f4e1ce9f618779b2dd1d9d84f1e32812c23a29b3fff6fd7f63fa5e"},
-]
-
-[[package]]
-name = "astroid"
-version = "2.14.1"
-description = "An abstract syntax tree for Python with inference support."
-optional = false
-python-versions = ">=3.7.2"
-groups = ["dev"]
-files = [
-    {file = "astroid-2.14.1-py3-none-any.whl", hash = "sha256:23c718921acab5f08cbbbe9293967f1f8fec40c336d19cd75dc12a9ea31d2eb2"},
-    {file = "astroid-2.14.1.tar.gz", hash = "sha256:bd1aa4f9915c98e8aaebcd4e71930154d4e8c9aaf05d35ac0a63d1956091ae3f"},
-]
-
-[package.dependencies]
-lazy-object-proxy = ">=1.4.0"
-wrapt = {version = ">=1.14,<2", markers = "python_version >= \"3.11\""}
-
-[[package]]
 name = "asttokens"
 version = "2.2.1"
 description = "Annotate AST trees with source code positions"
@@ -187,54 +159,6 @@ chardet = ["chardet"]
 charset-normalizer = ["charset-normalizer"]
 html5lib = ["html5lib"]
 lxml = ["lxml"]
-
-[[package]]
-name = "black"
-version = "23.1.0"
-description = "The uncompromising code formatter."
-optional = false
-python-versions = ">=3.7"
-groups = ["dev"]
-files = [
-    {file = "black-23.1.0-cp310-cp310-macosx_10_16_arm64.whl", hash = "sha256:b6a92a41ee34b883b359998f0c8e6eb8e99803aa8bf3123bf2b2e6fec505a221"},
-    {file = "black-23.1.0-cp310-cp310-macosx_10_16_universal2.whl", hash = "sha256:57c18c5165c1dbe291d5306e53fb3988122890e57bd9b3dcb75f967f13411a26"},
-    {file = "black-23.1.0-cp310-cp310-macosx_10_16_x86_64.whl", hash = "sha256:9880d7d419bb7e709b37e28deb5e68a49227713b623c72b2b931028ea65f619b"},
-    {file = "black-23.1.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e6663f91b6feca5d06f2ccd49a10f254f9298cc1f7f49c46e498a0771b507104"},
-    {file = "black-23.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:9afd3f493666a0cd8f8df9a0200c6359ac53940cbde049dcb1a7eb6ee2dd7074"},
-    {file = "black-23.1.0-cp311-cp311-macosx_10_16_arm64.whl", hash = "sha256:bfffba28dc52a58f04492181392ee380e95262af14ee01d4bc7bb1b1c6ca8d27"},
-    {file = "black-23.1.0-cp311-cp311-macosx_10_16_universal2.whl", hash = "sha256:c1c476bc7b7d021321e7d93dc2cbd78ce103b84d5a4cf97ed535fbc0d6660648"},
-    {file = "black-23.1.0-cp311-cp311-macosx_10_16_x86_64.whl", hash = "sha256:382998821f58e5c8238d3166c492139573325287820963d2f7de4d518bd76958"},
-    {file = "black-23.1.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2bf649fda611c8550ca9d7592b69f0637218c2369b7744694c5e4902873b2f3a"},
-    {file = "black-23.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:121ca7f10b4a01fd99951234abdbd97728e1240be89fde18480ffac16503d481"},
-    {file = "black-23.1.0-cp37-cp37m-macosx_10_16_x86_64.whl", hash = "sha256:a8471939da5e824b891b25751955be52ee7f8a30a916d570a5ba8e0f2eb2ecad"},
-    {file = "black-23.1.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8178318cb74f98bc571eef19068f6ab5613b3e59d4f47771582f04e175570ed8"},
-    {file = "black-23.1.0-cp37-cp37m-win_amd64.whl", hash = "sha256:a436e7881d33acaf2536c46a454bb964a50eff59b21b51c6ccf5a40601fbef24"},
-    {file = "black-23.1.0-cp38-cp38-macosx_10_16_arm64.whl", hash = "sha256:a59db0a2094d2259c554676403fa2fac3473ccf1354c1c63eccf7ae65aac8ab6"},
-    {file = "black-23.1.0-cp38-cp38-macosx_10_16_universal2.whl", hash = "sha256:0052dba51dec07ed029ed61b18183942043e00008ec65d5028814afaab9a22fd"},
-    {file = "black-23.1.0-cp38-cp38-macosx_10_16_x86_64.whl", hash = "sha256:49f7b39e30f326a34b5c9a4213213a6b221d7ae9d58ec70df1c4a307cf2a1580"},
-    {file = "black-23.1.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:162e37d49e93bd6eb6f1afc3e17a3d23a823042530c37c3c42eeeaf026f38468"},
-    {file = "black-23.1.0-cp38-cp38-win_amd64.whl", hash = "sha256:8b70eb40a78dfac24842458476135f9b99ab952dd3f2dab738c1881a9b38b753"},
-    {file = "black-23.1.0-cp39-cp39-macosx_10_16_arm64.whl", hash = "sha256:a29650759a6a0944e7cca036674655c2f0f63806ddecc45ed40b7b8aa314b651"},
-    {file = "black-23.1.0-cp39-cp39-macosx_10_16_universal2.whl", hash = "sha256:bb460c8561c8c1bec7824ecbc3ce085eb50005883a6203dcfb0122e95797ee06"},
-    {file = "black-23.1.0-cp39-cp39-macosx_10_16_x86_64.whl", hash = "sha256:c91dfc2c2a4e50df0026f88d2215e166616e0c80e86004d0003ece0488db2739"},
-    {file = "black-23.1.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2a951cc83ab535d248c89f300eccbd625e80ab880fbcfb5ac8afb5f01a258ac9"},
-    {file = "black-23.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:0680d4380db3719ebcfb2613f34e86c8e6d15ffeabcf8ec59355c5e7b85bb555"},
-    {file = "black-23.1.0-py3-none-any.whl", hash = "sha256:7a0f701d314cfa0896b9001df70a530eb2472babb76086344e688829efd97d32"},
-    {file = "black-23.1.0.tar.gz", hash = "sha256:b0bd97bea8903f5a2ba7219257a44e3f1f9d00073d6cc1add68f0beec69692ac"},
-]
-
-[package.dependencies]
-click = ">=8.0.0"
-mypy-extensions = ">=0.4.3"
-packaging = ">=22.0"
-pathspec = ">=0.9.0"
-platformdirs = ">=2"
-
-[package.extras]
-colorama = ["colorama (>=0.4.3)"]
-d = ["aiohttp (>=3.7.4)"]
-jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
-uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "blurhash"
@@ -497,7 +421,7 @@ version = "8.1.3"
 description = "Composable command line interface toolkit"
 optional = false
 python-versions = ">=3.7"
-groups = ["main", "dev"]
+groups = ["main"]
 files = [
     {file = "click-8.1.3-py3-none-any.whl", hash = "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"},
     {file = "click-8.1.3.tar.gz", hash = "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e"},
@@ -513,11 +437,11 @@ description = "Cross-platform colored terminal text."
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 groups = ["main", "dev"]
-markers = "platform_system == \"Windows\" or sys_platform == \"win32\""
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
+markers = {main = "platform_system == \"Windows\" or sys_platform == \"win32\"", dev = "sys_platform == \"win32\""}
 
 [[package]]
 name = "courts-db"
@@ -596,21 +520,6 @@ files = [
     {file = "decorator-5.1.1-py3-none-any.whl", hash = "sha256:b8c3f85900b9dc423225913c5aace94729fe1fa9763b38939a95226f02d37186"},
     {file = "decorator-5.1.1.tar.gz", hash = "sha256:637996211036b6385ef91435e4fae22989472f9d571faba8927ba8253acbc330"},
 ]
-
-[[package]]
-name = "dill"
-version = "0.3.6"
-description = "serialize all of python"
-optional = false
-python-versions = ">=3.7"
-groups = ["dev"]
-files = [
-    {file = "dill-0.3.6-py3-none-any.whl", hash = "sha256:a07ffd2351b8c678dfc4a856a3005f8067aea51d6ba6c700796a4d9e280f39f0"},
-    {file = "dill-0.3.6.tar.gz", hash = "sha256:e5db55f3687856d8fbdab002ed78544e1c4559a130302693d839dfe8f93f2373"},
-]
-
-[package.extras]
-graph = ["objgraph (>=1.7.2)"]
 
 [[package]]
 name = "disposable-email-domains"
@@ -989,42 +898,6 @@ testing = ["covdefaults (>=2.3)", "coverage (>=7.6.1)", "diff-cover (>=9.2)", "p
 typing = ["typing-extensions (>=4.12.2) ; python_version < \"3.11\""]
 
 [[package]]
-name = "flake8"
-version = "6.0.0"
-description = "the modular source code checker: pep8 pyflakes and co"
-optional = false
-python-versions = ">=3.8.1"
-groups = ["dev"]
-files = [
-    {file = "flake8-6.0.0-py2.py3-none-any.whl", hash = "sha256:3833794e27ff64ea4e9cf5d410082a8b97ff1a06c16aa3d2027339cd0f1195c7"},
-    {file = "flake8-6.0.0.tar.gz", hash = "sha256:c61007e76655af75e6785a931f452915b371dc48f56efd765247c8fe68f2b181"},
-]
-
-[package.dependencies]
-mccabe = ">=0.7.0,<0.8.0"
-pycodestyle = ">=2.10.0,<2.11.0"
-pyflakes = ">=3.0.0,<3.1.0"
-
-[[package]]
-name = "flynt"
-version = "0.77"
-description = "CLI tool to convert a python project's %-formatted strings to f-strings."
-optional = false
-python-versions = ">=3.7"
-groups = ["dev"]
-files = [
-    {file = "flynt-0.77-py3-none-any.whl", hash = "sha256:2863ac8ec19d6ec8d29e760546e6ced644baf6dff3c7cdc77e03abbd29b80f14"},
-    {file = "flynt-0.77.tar.gz", hash = "sha256:2bd1b37043ad88a3f3c3c34a76fc0b64d24e5f03d36ea6b48cb69cc642bff17e"},
-]
-
-[package.dependencies]
-astor = "*"
-tomli = ">=1.1.0"
-
-[package.extras]
-dev = ["build", "pre-commit", "pytest", "pytest-cov", "twine"]
-
-[[package]]
 name = "gunicorn"
 version = "23.0.0"
 description = "WSGI HTTP Server for UNIX"
@@ -1136,24 +1009,6 @@ files = [
 pygments = "*"
 
 [[package]]
-name = "isort"
-version = "5.12.0"
-description = "A Python utility / library to sort Python imports."
-optional = false
-python-versions = ">=3.8.0"
-groups = ["dev"]
-files = [
-    {file = "isort-5.12.0-py3-none-any.whl", hash = "sha256:f84c2818376e66cf843d497486ea8fed8700b340f308f076c6fb1229dff318b6"},
-    {file = "isort-5.12.0.tar.gz", hash = "sha256:8bef7dde241278824a6d83f44a544709b065191b95b6e50894bdc722fcba0504"},
-]
-
-[package.extras]
-colors = ["colorama (>=0.4.3)"]
-pipfile-deprecated-finder = ["pip-shims (>=0.5.2)", "pipreqs", "requirementslib"]
-plugins = ["setuptools"]
-requirements-deprecated-finder = ["pip-api", "pipreqs"]
-
-[[package]]
 name = "jedi"
 version = "0.18.2"
 description = "An autocompletion tool for Python that can be used for text editors."
@@ -1183,52 +1038,6 @@ groups = ["main"]
 files = [
     {file = "jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980"},
     {file = "jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe"},
-]
-
-[[package]]
-name = "lazy-object-proxy"
-version = "1.9.0"
-description = "A fast and thorough lazy object proxy."
-optional = false
-python-versions = ">=3.7"
-groups = ["dev"]
-files = [
-    {file = "lazy-object-proxy-1.9.0.tar.gz", hash = "sha256:659fb5809fa4629b8a1ac5106f669cfc7bef26fbb389dda53b3e010d1ac4ebae"},
-    {file = "lazy_object_proxy-1.9.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b40387277b0ed2d0602b8293b94d7257e17d1479e257b4de114ea11a8cb7f2d7"},
-    {file = "lazy_object_proxy-1.9.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e8c6cfb338b133fbdbc5cfaa10fe3c6aeea827db80c978dbd13bc9dd8526b7d4"},
-    {file = "lazy_object_proxy-1.9.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:721532711daa7db0d8b779b0bb0318fa87af1c10d7fe5e52ef30f8eff254d0cd"},
-    {file = "lazy_object_proxy-1.9.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:66a3de4a3ec06cd8af3f61b8e1ec67614fbb7c995d02fa224813cb7afefee701"},
-    {file = "lazy_object_proxy-1.9.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:1aa3de4088c89a1b69f8ec0dcc169aa725b0ff017899ac568fe44ddc1396df46"},
-    {file = "lazy_object_proxy-1.9.0-cp310-cp310-win32.whl", hash = "sha256:f0705c376533ed2a9e5e97aacdbfe04cecd71e0aa84c7c0595d02ef93b6e4455"},
-    {file = "lazy_object_proxy-1.9.0-cp310-cp310-win_amd64.whl", hash = "sha256:ea806fd4c37bf7e7ad82537b0757999264d5f70c45468447bb2b91afdbe73a6e"},
-    {file = "lazy_object_proxy-1.9.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:946d27deaff6cf8452ed0dba83ba38839a87f4f7a9732e8f9fd4107b21e6ff07"},
-    {file = "lazy_object_proxy-1.9.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:79a31b086e7e68b24b99b23d57723ef7e2c6d81ed21007b6281ebcd1688acb0a"},
-    {file = "lazy_object_proxy-1.9.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f699ac1c768270c9e384e4cbd268d6e67aebcfae6cd623b4d7c3bfde5a35db59"},
-    {file = "lazy_object_proxy-1.9.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:bfb38f9ffb53b942f2b5954e0f610f1e721ccebe9cce9025a38c8ccf4a5183a4"},
-    {file = "lazy_object_proxy-1.9.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:189bbd5d41ae7a498397287c408617fe5c48633e7755287b21d741f7db2706a9"},
-    {file = "lazy_object_proxy-1.9.0-cp311-cp311-win32.whl", hash = "sha256:81fc4d08b062b535d95c9ea70dbe8a335c45c04029878e62d744bdced5141586"},
-    {file = "lazy_object_proxy-1.9.0-cp311-cp311-win_amd64.whl", hash = "sha256:f2457189d8257dd41ae9b434ba33298aec198e30adf2dcdaaa3a28b9994f6adb"},
-    {file = "lazy_object_proxy-1.9.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:d9e25ef10a39e8afe59a5c348a4dbf29b4868ab76269f81ce1674494e2565a6e"},
-    {file = "lazy_object_proxy-1.9.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cbf9b082426036e19c6924a9ce90c740a9861e2bdc27a4834fd0a910742ac1e8"},
-    {file = "lazy_object_proxy-1.9.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9f5fa4a61ce2438267163891961cfd5e32ec97a2c444e5b842d574251ade27d2"},
-    {file = "lazy_object_proxy-1.9.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:8fa02eaab317b1e9e03f69aab1f91e120e7899b392c4fc19807a8278a07a97e8"},
-    {file = "lazy_object_proxy-1.9.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:e7c21c95cae3c05c14aafffe2865bbd5e377cfc1348c4f7751d9dc9a48ca4bda"},
-    {file = "lazy_object_proxy-1.9.0-cp37-cp37m-win32.whl", hash = "sha256:f12ad7126ae0c98d601a7ee504c1122bcef553d1d5e0c3bfa77b16b3968d2734"},
-    {file = "lazy_object_proxy-1.9.0-cp37-cp37m-win_amd64.whl", hash = "sha256:edd20c5a55acb67c7ed471fa2b5fb66cb17f61430b7a6b9c3b4a1e40293b1671"},
-    {file = "lazy_object_proxy-1.9.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:2d0daa332786cf3bb49e10dc6a17a52f6a8f9601b4cf5c295a4f85854d61de63"},
-    {file = "lazy_object_proxy-1.9.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9cd077f3d04a58e83d04b20e334f678c2b0ff9879b9375ed107d5d07ff160171"},
-    {file = "lazy_object_proxy-1.9.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:660c94ea760b3ce47d1855a30984c78327500493d396eac4dfd8bd82041b22be"},
-    {file = "lazy_object_proxy-1.9.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:212774e4dfa851e74d393a2370871e174d7ff0ebc980907723bb67d25c8a7c30"},
-    {file = "lazy_object_proxy-1.9.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:f0117049dd1d5635bbff65444496c90e0baa48ea405125c088e93d9cf4525b11"},
-    {file = "lazy_object_proxy-1.9.0-cp38-cp38-win32.whl", hash = "sha256:0a891e4e41b54fd5b8313b96399f8b0e173bbbfc03c7631f01efbe29bb0bcf82"},
-    {file = "lazy_object_proxy-1.9.0-cp38-cp38-win_amd64.whl", hash = "sha256:9990d8e71b9f6488e91ad25f322898c136b008d87bf852ff65391b004da5e17b"},
-    {file = "lazy_object_proxy-1.9.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9e7551208b2aded9c1447453ee366f1c4070602b3d932ace044715d89666899b"},
-    {file = "lazy_object_proxy-1.9.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5f83ac4d83ef0ab017683d715ed356e30dd48a93746309c8f3517e1287523ef4"},
-    {file = "lazy_object_proxy-1.9.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7322c3d6f1766d4ef1e51a465f47955f1e8123caee67dd641e67d539a534d006"},
-    {file = "lazy_object_proxy-1.9.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:18b78ec83edbbeb69efdc0e9c1cb41a3b1b1ed11ddd8ded602464c3fc6020494"},
-    {file = "lazy_object_proxy-1.9.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:09763491ce220c0299688940f8dc2c5d05fd1f45af1e42e636b2e8b2303e4382"},
-    {file = "lazy_object_proxy-1.9.0-cp39-cp39-win32.whl", hash = "sha256:9090d8e53235aa280fc9239a86ae3ea8ac58eff66a705fa6aa2ec4968b95c821"},
-    {file = "lazy_object_proxy-1.9.0-cp39-cp39-win_amd64.whl", hash = "sha256:db1c1722726f47e10e0b5fdbf15ac3b8adb58c091d12b3ab713965795036985f"},
 ]
 
 [[package]]
@@ -1272,18 +1081,6 @@ files = [
 
 [package.dependencies]
 traitlets = "*"
-
-[[package]]
-name = "mccabe"
-version = "0.7.0"
-description = "McCabe checker, plugin for flake8"
-optional = false
-python-versions = ">=3.6"
-groups = ["dev"]
-files = [
-    {file = "mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"},
-    {file = "mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325"},
-]
 
 [[package]]
 name = "mypy"
@@ -1382,7 +1179,7 @@ version = "23.0"
 description = "Core utilities for Python packages"
 optional = false
 python-versions = ">=3.7"
-groups = ["main", "dev"]
+groups = ["main"]
 files = [
     {file = "packaging-23.0-py3-none-any.whl", hash = "sha256:714ac14496c3e68c99c29b00845f7a2b85f3bb6f1078fd9f72fd20f0570002b2"},
     {file = "packaging-23.0.tar.gz", hash = "sha256:b6ad297f8907de0fa2fe1ccbd26fdaf387f5f47c7275fedf8cce89f99446cf97"},
@@ -1403,18 +1200,6 @@ files = [
 [package.extras]
 qa = ["flake8 (==3.8.3)", "mypy (==0.782)"]
 testing = ["docopt", "pytest (<6.0.0)"]
-
-[[package]]
-name = "pathspec"
-version = "0.11.0"
-description = "Utility library for gitignore style pattern matching of file paths."
-optional = false
-python-versions = ">=3.7"
-groups = ["dev"]
-files = [
-    {file = "pathspec-0.11.0-py3-none-any.whl", hash = "sha256:3a66eb970cbac598f9e5ccb5b2cf58930cd8e3ed86d393d541eaf2d8b1705229"},
-    {file = "pathspec-0.11.0.tar.gz", hash = "sha256:64d338d4e0914e91c1792321e6907b5a593f1ab1851de7fc269557a21b30ebbc"},
-]
 
 [[package]]
 name = "pexpect"
@@ -1691,18 +1476,6 @@ files = [
 tests = ["pytest"]
 
 [[package]]
-name = "pycodestyle"
-version = "2.10.0"
-description = "Python style guide checker"
-optional = false
-python-versions = ">=3.6"
-groups = ["dev"]
-files = [
-    {file = "pycodestyle-2.10.0-py2.py3-none-any.whl", hash = "sha256:8a4eaf0d0495c7395bdab3589ac2db602797d76207242c17d470186815706610"},
-    {file = "pycodestyle-2.10.0.tar.gz", hash = "sha256:347187bdb476329d98f695c213d7295a846d1152ff4fe9bacb8a9590b8ee7053"},
-]
-
-[[package]]
 name = "pycparser"
 version = "2.21"
 description = "C parser in Python"
@@ -1714,18 +1487,6 @@ files = [
     {file = "pycparser-2.21.tar.gz", hash = "sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"},
 ]
 markers = {dev = "platform_python_implementation != \"PyPy\""}
-
-[[package]]
-name = "pyflakes"
-version = "3.0.1"
-description = "passive checker of Python programs"
-optional = false
-python-versions = ">=3.6"
-groups = ["dev"]
-files = [
-    {file = "pyflakes-3.0.1-py2.py3-none-any.whl", hash = "sha256:ec55bf7fe21fff7f1ad2f7da62363d749e2a470500eab1b555334b67aa1ef8cf"},
-    {file = "pyflakes-3.0.1.tar.gz", hash = "sha256:ec8b276a6b60bd80defed25add7e439881c19e64850afd9b346283d4165fd0fd"},
-]
 
 [[package]]
 name = "pygments"
@@ -1741,31 +1502,6 @@ files = [
 
 [package.extras]
 plugins = ["importlib-metadata ; python_version < \"3.8\""]
-
-[[package]]
-name = "pylint"
-version = "2.16.1"
-description = "python code static checker"
-optional = false
-python-versions = ">=3.7.2"
-groups = ["dev"]
-files = [
-    {file = "pylint-2.16.1-py3-none-any.whl", hash = "sha256:bad9d7c36037f6043a1e848a43004dfd5ea5ceb05815d713ba56ca4503a9fe37"},
-    {file = "pylint-2.16.1.tar.gz", hash = "sha256:ffe7fa536bb38ba35006a7c8a6d2efbfdd3d95bbf21199cad31f76b1c50aaf30"},
-]
-
-[package.dependencies]
-astroid = ">=2.14.1,<=2.16.0-dev0"
-colorama = {version = ">=0.4.5", markers = "sys_platform == \"win32\""}
-dill = {version = ">=0.3.6", markers = "python_version >= \"3.11\""}
-isort = ">=4.2.5,<6"
-mccabe = ">=0.6,<0.8"
-platformdirs = ">=2.2.0"
-tomlkit = ">=0.10.1"
-
-[package.extras]
-spelling = ["pyenchant (>=3.2,<4.0)"]
-testutils = ["gitpython (>3)"]
 
 [[package]]
 name = "python-dateutil"
@@ -2102,30 +1838,6 @@ pure-eval = "*"
 tests = ["cython", "littleutils", "pygments", "pytest", "typeguard"]
 
 [[package]]
-name = "tomli"
-version = "2.0.1"
-description = "A lil' TOML parser"
-optional = false
-python-versions = ">=3.7"
-groups = ["dev"]
-files = [
-    {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
-    {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
-]
-
-[[package]]
-name = "tomlkit"
-version = "0.11.6"
-description = "Style preserving TOML library"
-optional = false
-python-versions = ">=3.6"
-groups = ["dev"]
-files = [
-    {file = "tomlkit-0.11.6-py3-none-any.whl", hash = "sha256:07de26b0d8cfc18f871aec595fda24d95b08fef89d147caa861939f37230bf4b"},
-    {file = "tomlkit-0.11.6.tar.gz", hash = "sha256:71b952e5721688937fb02cf9d354dbcf0785066149d2855e44531ebdd2b65d73"},
-]
-
-[[package]]
 name = "traitlets"
 version = "5.14.2"
 description = "Traitlets Python configuration system"
@@ -2305,91 +2017,7 @@ files = [
 [package.extras]
 test = ["pytest (>=6.0.0)", "setuptools (>=65)"]
 
-[[package]]
-name = "wrapt"
-version = "1.14.1"
-description = "Module for decorators, wrappers and monkey patching."
-optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
-groups = ["dev"]
-files = [
-    {file = "wrapt-1.14.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:1b376b3f4896e7930f1f772ac4b064ac12598d1c38d04907e696cc4d794b43d3"},
-    {file = "wrapt-1.14.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:903500616422a40a98a5a3c4ff4ed9d0066f3b4c951fa286018ecdf0750194ef"},
-    {file = "wrapt-1.14.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:5a9a0d155deafd9448baff28c08e150d9b24ff010e899311ddd63c45c2445e28"},
-    {file = "wrapt-1.14.1-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:ddaea91abf8b0d13443f6dac52e89051a5063c7d014710dcb4d4abb2ff811a59"},
-    {file = "wrapt-1.14.1-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:36f582d0c6bc99d5f39cd3ac2a9062e57f3cf606ade29a0a0d6b323462f4dd87"},
-    {file = "wrapt-1.14.1-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:7ef58fb89674095bfc57c4069e95d7a31cfdc0939e2a579882ac7d55aadfd2a1"},
-    {file = "wrapt-1.14.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:e2f83e18fe2f4c9e7db597e988f72712c0c3676d337d8b101f6758107c42425b"},
-    {file = "wrapt-1.14.1-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:ee2b1b1769f6707a8a445162ea16dddf74285c3964f605877a20e38545c3c462"},
-    {file = "wrapt-1.14.1-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:833b58d5d0b7e5b9832869f039203389ac7cbf01765639c7309fd50ef619e0b1"},
-    {file = "wrapt-1.14.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:80bb5c256f1415f747011dc3604b59bc1f91c6e7150bd7db03b19170ee06b320"},
-    {file = "wrapt-1.14.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:07f7a7d0f388028b2df1d916e94bbb40624c59b48ecc6cbc232546706fac74c2"},
-    {file = "wrapt-1.14.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:02b41b633c6261feff8ddd8d11c711df6842aba629fdd3da10249a53211a72c4"},
-    {file = "wrapt-1.14.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2fe803deacd09a233e4762a1adcea5db5d31e6be577a43352936179d14d90069"},
-    {file = "wrapt-1.14.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:257fd78c513e0fb5cdbe058c27a0624c9884e735bbd131935fd49e9fe719d310"},
-    {file = "wrapt-1.14.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:4fcc4649dc762cddacd193e6b55bc02edca674067f5f98166d7713b193932b7f"},
-    {file = "wrapt-1.14.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:11871514607b15cfeb87c547a49bca19fde402f32e2b1c24a632506c0a756656"},
-    {file = "wrapt-1.14.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:8ad85f7f4e20964db4daadcab70b47ab05c7c1cf2a7c1e51087bfaa83831854c"},
-    {file = "wrapt-1.14.1-cp310-cp310-win32.whl", hash = "sha256:a9a52172be0b5aae932bef82a79ec0a0ce87288c7d132946d645eba03f0ad8a8"},
-    {file = "wrapt-1.14.1-cp310-cp310-win_amd64.whl", hash = "sha256:6d323e1554b3d22cfc03cd3243b5bb815a51f5249fdcbb86fda4bf62bab9e164"},
-    {file = "wrapt-1.14.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ecee4132c6cd2ce5308e21672015ddfed1ff975ad0ac8d27168ea82e71413f55"},
-    {file = "wrapt-1.14.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2020f391008ef874c6d9e208b24f28e31bcb85ccff4f335f15a3251d222b92d9"},
-    {file = "wrapt-1.14.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2feecf86e1f7a86517cab34ae6c2f081fd2d0dac860cb0c0ded96d799d20b335"},
-    {file = "wrapt-1.14.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:240b1686f38ae665d1b15475966fe0472f78e71b1b4903c143a842659c8e4cb9"},
-    {file = "wrapt-1.14.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a9008dad07d71f68487c91e96579c8567c98ca4c3881b9b113bc7b33e9fd78b8"},
-    {file = "wrapt-1.14.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:6447e9f3ba72f8e2b985a1da758767698efa72723d5b59accefd716e9e8272bf"},
-    {file = "wrapt-1.14.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:acae32e13a4153809db37405f5eba5bac5fbe2e2ba61ab227926a22901051c0a"},
-    {file = "wrapt-1.14.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:49ef582b7a1152ae2766557f0550a9fcbf7bbd76f43fbdc94dd3bf07cc7168be"},
-    {file = "wrapt-1.14.1-cp311-cp311-win32.whl", hash = "sha256:358fe87cc899c6bb0ddc185bf3dbfa4ba646f05b1b0b9b5a27c2cb92c2cea204"},
-    {file = "wrapt-1.14.1-cp311-cp311-win_amd64.whl", hash = "sha256:26046cd03936ae745a502abf44dac702a5e6880b2b01c29aea8ddf3353b68224"},
-    {file = "wrapt-1.14.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:43ca3bbbe97af00f49efb06e352eae40434ca9d915906f77def219b88e85d907"},
-    {file = "wrapt-1.14.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:6b1a564e6cb69922c7fe3a678b9f9a3c54e72b469875aa8018f18b4d1dd1adf3"},
-    {file = "wrapt-1.14.1-cp35-cp35m-manylinux2010_i686.whl", hash = "sha256:00b6d4ea20a906c0ca56d84f93065b398ab74b927a7a3dbd470f6fc503f95dc3"},
-    {file = "wrapt-1.14.1-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:a85d2b46be66a71bedde836d9e41859879cc54a2a04fad1191eb50c2066f6e9d"},
-    {file = "wrapt-1.14.1-cp35-cp35m-win32.whl", hash = "sha256:dbcda74c67263139358f4d188ae5faae95c30929281bc6866d00573783c422b7"},
-    {file = "wrapt-1.14.1-cp35-cp35m-win_amd64.whl", hash = "sha256:b21bb4c09ffabfa0e85e3a6b623e19b80e7acd709b9f91452b8297ace2a8ab00"},
-    {file = "wrapt-1.14.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:9e0fd32e0148dd5dea6af5fee42beb949098564cc23211a88d799e434255a1f4"},
-    {file = "wrapt-1.14.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9736af4641846491aedb3c3f56b9bc5568d92b0692303b5a305301a95dfd38b1"},
-    {file = "wrapt-1.14.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5b02d65b9ccf0ef6c34cba6cf5bf2aab1bb2f49c6090bafeecc9cd81ad4ea1c1"},
-    {file = "wrapt-1.14.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:21ac0156c4b089b330b7666db40feee30a5d52634cc4560e1905d6529a3897ff"},
-    {file = "wrapt-1.14.1-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:9f3e6f9e05148ff90002b884fbc2a86bd303ae847e472f44ecc06c2cd2fcdb2d"},
-    {file = "wrapt-1.14.1-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:6e743de5e9c3d1b7185870f480587b75b1cb604832e380d64f9504a0535912d1"},
-    {file = "wrapt-1.14.1-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:d79d7d5dc8a32b7093e81e97dad755127ff77bcc899e845f41bf71747af0c569"},
-    {file = "wrapt-1.14.1-cp36-cp36m-win32.whl", hash = "sha256:81b19725065dcb43df02b37e03278c011a09e49757287dca60c5aecdd5a0b8ed"},
-    {file = "wrapt-1.14.1-cp36-cp36m-win_amd64.whl", hash = "sha256:b014c23646a467558be7da3d6b9fa409b2c567d2110599b7cf9a0c5992b3b471"},
-    {file = "wrapt-1.14.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:88bd7b6bd70a5b6803c1abf6bca012f7ed963e58c68d76ee20b9d751c74a3248"},
-    {file = "wrapt-1.14.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b5901a312f4d14c59918c221323068fad0540e34324925c8475263841dbdfe68"},
-    {file = "wrapt-1.14.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d77c85fedff92cf788face9bfa3ebaa364448ebb1d765302e9af11bf449ca36d"},
-    {file = "wrapt-1.14.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8d649d616e5c6a678b26d15ece345354f7c2286acd6db868e65fcc5ff7c24a77"},
-    {file = "wrapt-1.14.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:7d2872609603cb35ca513d7404a94d6d608fc13211563571117046c9d2bcc3d7"},
-    {file = "wrapt-1.14.1-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:ee6acae74a2b91865910eef5e7de37dc6895ad96fa23603d1d27ea69df545015"},
-    {file = "wrapt-1.14.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:2b39d38039a1fdad98c87279b48bc5dce2c0ca0d73483b12cb72aa9609278e8a"},
-    {file = "wrapt-1.14.1-cp37-cp37m-win32.whl", hash = "sha256:60db23fa423575eeb65ea430cee741acb7c26a1365d103f7b0f6ec412b893853"},
-    {file = "wrapt-1.14.1-cp37-cp37m-win_amd64.whl", hash = "sha256:709fe01086a55cf79d20f741f39325018f4df051ef39fe921b1ebe780a66184c"},
-    {file = "wrapt-1.14.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:8c0ce1e99116d5ab21355d8ebe53d9460366704ea38ae4d9f6933188f327b456"},
-    {file = "wrapt-1.14.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:e3fb1677c720409d5f671e39bac6c9e0e422584e5f518bfd50aa4cbbea02433f"},
-    {file = "wrapt-1.14.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:642c2e7a804fcf18c222e1060df25fc210b9c58db7c91416fb055897fc27e8cc"},
-    {file = "wrapt-1.14.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7b7c050ae976e286906dd3f26009e117eb000fb2cf3533398c5ad9ccc86867b1"},
-    {file = "wrapt-1.14.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ef3f72c9666bba2bab70d2a8b79f2c6d2c1a42a7f7e2b0ec83bb2f9e383950af"},
-    {file = "wrapt-1.14.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:01c205616a89d09827986bc4e859bcabd64f5a0662a7fe95e0d359424e0e071b"},
-    {file = "wrapt-1.14.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:5a0f54ce2c092aaf439813735584b9537cad479575a09892b8352fea5e988dc0"},
-    {file = "wrapt-1.14.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:2cf71233a0ed05ccdabe209c606fe0bac7379fdcf687f39b944420d2a09fdb57"},
-    {file = "wrapt-1.14.1-cp38-cp38-win32.whl", hash = "sha256:aa31fdcc33fef9eb2552cbcbfee7773d5a6792c137b359e82879c101e98584c5"},
-    {file = "wrapt-1.14.1-cp38-cp38-win_amd64.whl", hash = "sha256:d1967f46ea8f2db647c786e78d8cc7e4313dbd1b0aca360592d8027b8508e24d"},
-    {file = "wrapt-1.14.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3232822c7d98d23895ccc443bbdf57c7412c5a65996c30442ebe6ed3df335383"},
-    {file = "wrapt-1.14.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:988635d122aaf2bdcef9e795435662bcd65b02f4f4c1ae37fbee7401c440b3a7"},
-    {file = "wrapt-1.14.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9cca3c2cdadb362116235fdbd411735de4328c61425b0aa9f872fd76d02c4e86"},
-    {file = "wrapt-1.14.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d52a25136894c63de15a35bc0bdc5adb4b0e173b9c0d07a2be9d3ca64a332735"},
-    {file = "wrapt-1.14.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:40e7bc81c9e2b2734ea4bc1aceb8a8f0ceaac7c5299bc5d69e37c44d9081d43b"},
-    {file = "wrapt-1.14.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:b9b7a708dd92306328117d8c4b62e2194d00c365f18eff11a9b53c6f923b01e3"},
-    {file = "wrapt-1.14.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:6a9a25751acb379b466ff6be78a315e2b439d4c94c1e99cb7266d40a537995d3"},
-    {file = "wrapt-1.14.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:34aa51c45f28ba7f12accd624225e2b1e5a3a45206aa191f6f9aac931d9d56fe"},
-    {file = "wrapt-1.14.1-cp39-cp39-win32.whl", hash = "sha256:dee0ce50c6a2dd9056c20db781e9c1cfd33e77d2d569f5d1d9321c641bb903d5"},
-    {file = "wrapt-1.14.1-cp39-cp39-win_amd64.whl", hash = "sha256:dee60e1de1898bde3b238f18340eec6148986da0455d8ba7848d50470a7a32fb"},
-    {file = "wrapt-1.14.1.tar.gz", hash = "sha256:380a85cf89e0e69b7cfbe2ea9f765f004ff419f34194018a6827ac0e3edfed4d"},
-]
-
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "9188e1d2d1968eaad68ac280b647f11aedf73509bd44830e530e6169d45621b3"
+content-hash = "2ee5c7c13798e70e275201516cc7b010e2d68580ad38c8c31db44f09d0289e84"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,14 +61,9 @@ beautifulsoup4 = "^4.13.3"
 django-permissions-policy = "^4.25.0"
 
 [tool.poetry.group.dev.dependencies]
-black = "^23.1.0"
-flake8 = "^6.0.0"
-isort = "^5.12.0"
 mypy = "^1.10.0"
-pylint = "^2.16.1"
 wheel = "^0.45.1"
 pre-commit = "^4.1.0"
-flynt = "^0.77"
 django-stubs = "^5.1.0"
 types-requests = "^2.32.0.20240523"
 types-redis = "^4.6.0.2"
@@ -76,26 +71,8 @@ ipython = "^9.0.2"
 django-debug-toolbar = "^5.0.1"
 django-tailwind = {extras = ["reload"], version = "^3.8.0"}
 
-[tool.black]
-include = '''.*\.pyi?$'''
-exclude = '''
-(
-      \.eggs
-    | .*\.egg-info
-    | .*migrations.*
-    | \.mypy_cache
-    | __pycache__
-    | \.venv
-)
-'''
-line-length = 79
-
 [tool.'django-stubs']
 django_settings_module = "bc.settings"
-
-[tool.isort]
-profile = "black"
-line_length = 79
 
 [tool.mypy]
 ignore_missing_imports = true
@@ -106,11 +83,38 @@ exclude = "migrations/*"
 module="django_stubs_ext.*"
 follow_imports="normal"
 
-[tool.pylint.messages_control]
-disable = "C0330, C0326"
-
-[tool.pylint.format]
-max-line-length = "79"
+[tool.ruff]
+line-length = 79
+lint.select = [
+  # flake8-bugbear
+  "B",
+  # flake8-comprehensions
+  "C4",
+  # pycodestyle
+  "E",
+  # Pyflakes errors
+  "F",
+  # isort
+  "I",
+  # flake8-simplify
+  "SIM",
+  # flake8-tidy-imports
+  "TID",
+  # pyupgrade
+  "UP",
+  # Pyflakes warnings
+  "W",
+]
+lint.ignore = [
+  # flake8-bugbear opinionated rules
+  "B9",
+  # line-too-long
+  "E501",
+  # suppressible-exception
+  "SIM105",
+  # if-else-block-instead-of-if-exp
+  "SIM108",
+]
 
 [build-system]
 build-backend = "poetry.core.masonry.api"

--- a/scripts/get-threads-keys.py
+++ b/scripts/get-threads-keys.py
@@ -1,4 +1,3 @@
-import json
 from datetime import datetime, timedelta, timezone
 
 import environ


### PR DESCRIPTION
Replace Black, isort, pylint, and pyupgrade with Ruff.

I did not add the `project` metadata in `pyproject.toml` for this repository because Poetry reports a conflict with its `tool.poetry` metadata. I'll add `project` only when converting to uv.