### PR TITLE
fix(docker): Remove outdated compose version numbers

### DIFF
--- a/docker/bigcasesbot/docker-compose.yml
+++ b/docker/bigcasesbot/docker-compose.yml
@@ -1,6 +1,4 @@
 # Run using `docker-compose up`
-version: "3.7"
-
 networks:
   bc2_net_overlay:
     driver: bridge


### PR DESCRIPTION
Copy of https://github.com/freelawproject/courtlistener/pull/5513 for this repository.