### PR TITLE
Do not escape variables in follow-new-case templates

### DIFF
--- a/bc/core/tests/test_templates.py
+++ b/bc/core/tests/test_templates.py
@@ -8,8 +8,8 @@ from bc.channel.utils.connectors.bluesky_api.client import BlueskyAPI
 from bc.core.utils.status.templates import (
     BLUESKY_FOLLOW_A_NEW_CASE,
     MASTODON_FOLLOW_A_NEW_CASE,
-    TWITTER_FOLLOW_A_NEW_CASE,
     THREADS_FOLLOW_A_NEW_CASE,
+    TWITTER_FOLLOW_A_NEW_CASE,
     MastodonTemplate,
 )
 from bc.core.utils.tests.base import faker
@@ -850,15 +850,13 @@ class NoEscapeTemplateTest(SimpleTestCase):
             docket_link=fake_docket_link,
             docket_id=fake_docket_id,
         )
-        correct_message = """I'm now following someone's case:
+        correct_message = f"""I'm now following someone's case:
 
-Docket: {docket_link}
+Docket: {fake_docket_link}
 
-#CL{docket_id}""".format(docket_link=fake_docket_link,
-            docket_id=fake_docket_id)
+#CL{fake_docket_id}"""
 
         self.assertEqual(message, correct_message)
-
 
     def test_twitter_follow_new_case_template_no_escape(self):
         fake_docket_url = faker.url()
@@ -870,15 +868,13 @@ Docket: {docket_link}
             docket_id=fake_docket_id,
         )
 
-        correct_message = """I'm now following someone's case:
+        correct_message = f"""I'm now following someone's case:
 
-Docket: {docket_link}
+Docket: {fake_docket_url}
 
-#CL{docket_id}""".format(docket_link=fake_docket_url,
-            docket_id=fake_docket_id,)
+#CL{fake_docket_id}"""
 
         self.assertEqual(message, correct_message)
-
 
     def test_bluesky_follow_new_case_template_no_escape(self):
         fake_docket_url = faker.url()
@@ -890,15 +886,13 @@ Docket: {docket_link}
             docket_id=fake_docket_id,
         )
 
-        correct_message = """I'm now following someone's case:
+        correct_message = f"""I'm now following someone's case:
 
-[View Full Case]({docket_link})
+[View Full Case]({fake_docket_url})
 
-#CL{docket_id}""".format(docket_link=fake_docket_url,
-            docket_id=fake_docket_id,)
+#CL{fake_docket_id}"""
 
         self.assertEqual(message, correct_message)
-
 
     def test_threads_follow_new_case_template_no_escape(self):
         fake_docket_url = faker.url()
@@ -910,11 +904,10 @@ Docket: {docket_link}
             docket_id=fake_docket_id,
         )
 
-        correct_message = """I'm now following someone's case:
+        correct_message = f"""I'm now following someone's case:
 
-Docket: {docket_link}
+Docket: {fake_docket_url}
 
-#CL{docket_id}""".format(docket_link=fake_docket_url,
-            docket_id=fake_docket_id,)
+#CL{fake_docket_id}"""
 
         self.assertEqual(message, correct_message)

--- a/bc/core/tests/test_templates.py
+++ b/bc/core/tests/test_templates.py
@@ -837,7 +837,6 @@ class BlueskyTemplateTest(SimpleTestCase):
 
 
 class NoEscapeTemplateTest(SimpleTestCase):
-
     def test_mastodon_follow_new_case_template_no_escape(self):
         fake_docket_link = faker.url()
         fake_docket_id = faker.random_int(100_000, 400_000)

--- a/bc/core/tests/test_templates.py
+++ b/bc/core/tests/test_templates.py
@@ -9,6 +9,7 @@ from bc.core.utils.status.templates import (
     BLUESKY_FOLLOW_A_NEW_CASE,
     MASTODON_FOLLOW_A_NEW_CASE,
     TWITTER_FOLLOW_A_NEW_CASE,
+    THREADS_FOLLOW_A_NEW_CASE,
     MastodonTemplate,
 )
 from bc.core.utils.tests.base import faker
@@ -837,3 +838,83 @@ class BlueskyTemplateTest(SimpleTestCase):
         # the content of the post to enclose embedded links
         pattern = r"View Full Case | Complaint | Context"
         self.assertIsNotNone(re.search(pattern, post_content))
+
+
+class NoEscapeTemplateTest(SimpleTestCase):
+
+    def test_mastodon_follow_new_case_template_no_escape(self):
+        fake_docket_link = faker.url()
+        fake_docket_id = faker.random_int(100_000, 400_000)
+        message, _ = MASTODON_FOLLOW_A_NEW_CASE.format(
+            docket="someone's case",
+            docket_link=fake_docket_link,
+            docket_id=fake_docket_id,
+        )
+        correct_message = """I'm now following someone's case:
+
+Docket: {docket_link}
+
+#CL{docket_id}""".format(docket_link=fake_docket_link,
+            docket_id=fake_docket_id)
+
+        self.assertEqual(message, correct_message)
+
+
+    def test_twitter_follow_new_case_template_no_escape(self):
+        fake_docket_url = faker.url()
+        fake_docket_id = faker.random_int(100_000, 400_000)
+
+        message, _ = TWITTER_FOLLOW_A_NEW_CASE.format(
+            docket="someone's case",
+            docket_link=fake_docket_url,
+            docket_id=fake_docket_id,
+        )
+
+        correct_message = """I'm now following someone's case:
+
+Docket: {docket_link}
+
+#CL{docket_id}""".format(docket_link=fake_docket_url,
+            docket_id=fake_docket_id,)
+
+        self.assertEqual(message, correct_message)
+
+
+    def test_bluesky_follow_new_case_template_no_escape(self):
+        fake_docket_url = faker.url()
+        fake_docket_id = faker.random_int(100_000, 400_000)
+
+        message, _ = BLUESKY_FOLLOW_A_NEW_CASE.format(
+            docket="someone's case",
+            docket_link=fake_docket_url,
+            docket_id=fake_docket_id,
+        )
+
+        correct_message = """I'm now following someone's case:
+
+[View Full Case]({docket_link})
+
+#CL{docket_id}""".format(docket_link=fake_docket_url,
+            docket_id=fake_docket_id,)
+
+        self.assertEqual(message, correct_message)
+
+
+    def test_threads_follow_new_case_template_no_escape(self):
+        fake_docket_url = faker.url()
+        fake_docket_id = faker.random_int(100_000, 400_000)
+
+        message, _ = THREADS_FOLLOW_A_NEW_CASE.format(
+            docket="someone's case",
+            docket_link=fake_docket_url,
+            docket_id=fake_docket_id,
+        )
+
+        correct_message = """I'm now following someone's case:
+
+Docket: {docket_link}
+
+#CL{docket_id}""".format(docket_link=fake_docket_url,
+            docket_id=fake_docket_id,)
+
+        self.assertEqual(message, correct_message)

--- a/bc/core/utils/status/templates.py
+++ b/bc/core/utils/status/templates.py
@@ -51,7 +51,7 @@ Docket: {docket_link}
 
 MASTODON_FOLLOW_A_NEW_CASE = MastodonTemplate(
     link_placeholders=["docket_link", "initial_complaint_link", "article_url"],
-    str_template="""I'm now following {{docket}}:{% if date_filed %}
+    str_template="""{% autoescape off %}I'm now following {{docket}}:{% if date_filed %}
 
 Filed: {{date_filed}}{% endif %}
 
@@ -61,7 +61,7 @@ Docket: {{docket_link}}{% if initial_complaint_type and initial_complaint_link %
 
 Context: {{article_url}}{% endif %}
 
-#CL{{docket_id}}""",
+#CL{{docket_id}}{% endautoescape %}""",
 )
 
 
@@ -86,7 +86,7 @@ Docket: {docket_link}
 
 TWITTER_FOLLOW_A_NEW_CASE = TwitterTemplate(
     link_placeholders=["docket_link", "initial_complaint_link", "article_url"],
-    str_template="""I'm now following {{docket}}:{% if date_filed %}
+    str_template="""{% autoescape off %}I'm now following {{docket}}:{% if date_filed %}
 
 Filed: {{date_filed}}{% endif %}
 
@@ -96,19 +96,19 @@ Docket: {{docket_link}}{% if initial_complaint_type and initial_complaint_link %
 
 Context: {{article_url}}{% endif %}
 
-#CL{{docket_id}}""",
+#CL{{docket_id}}{% endautoescape %}""",
 )
 
 BLUESKY_FOLLOW_A_NEW_CASE = BlueskyTemplate(
     link_placeholders=["docket_link", "article_url", "initial_complaint_link"],
     # Remove extra newlines caused by empty template blocks
-    str_template="""I'm now following {{docket}}:{% if date_filed %}
+    str_template="""{% autoescape off %}I'm now following {{docket}}:{% if date_filed %}
 
 Filed: {{date_filed}}{% endif %}
 
 [View Full Case]({{docket_link}}){% if article_url %} | [Background Info]({{article_url}}){% endif %}{% if initial_complaint_type and initial_complaint_link %} | [{{initial_complaint_type}}]({{initial_complaint_link}}){% endif %}
 
-#CL{{docket_id}}""",
+#CL{{docket_id}}{% endautoescape %}""",
 )
 
 BLUESKY_POST_TEMPLATE = BlueskyTemplate(
@@ -152,7 +152,7 @@ Docket: {docket_link}
 
 THREADS_FOLLOW_A_NEW_CASE = ThreadsTemplate(
     link_placeholders=["docket_link", "initial_complaint_link", "article_url"],
-    str_template="""I'm now following {{docket}}:{% if date_filed %}
+    str_template="""{% autoescape off %}I'm now following {{docket}}:{% if date_filed %}
 
 Filed: {{date_filed}}{% endif %}
 
@@ -162,5 +162,5 @@ Docket: {{docket_link}}{% if initial_complaint_type and initial_complaint_link %
 
 Context: {{article_url}}{% endif %}
 
-#CL{{docket_id}}""",
+#CL{{docket_id}}{% endautoescape %}""",
 )


### PR DESCRIPTION
Fix for #617. Apostrophes and other punctuation for Django templates were getting mangled because Django autoescapes HTML characters. This PR fixes the issue by enclosing the Big Cases Bot templates that are Django templates—the Follow-New-Case templates—within the Django `autoescape` tag. The tests added failed without the code change, and passed after the code change.